### PR TITLE
fix: exact ep square handling

### DIFF
--- a/app/src/game/book/pgn_reader.cpp
+++ b/app/src/game/book/pgn_reader.cpp
@@ -52,7 +52,7 @@ class PGNVisitor : public chess::pgn::Visitor {
             return;
         }
 
-        board_.makeMove(move_i);
+        board_.makeMove<true>(move_i);
 
         if (board_.isGameOver().second != chess::GameResult::NONE) {
             early_stop_ = true;

--- a/app/src/game/epd/epd_builder.hpp
+++ b/app/src/game/epd/epd_builder.hpp
@@ -23,7 +23,7 @@ class EpdBuilder {
 
             if (illegal) break;
 
-            board.makeMove(chess::uci::uciToMove(board, move.move));
+            board.makeMove<true>(chess::uci::uciToMove(board, move.move));
         }
 
         epd << board.getEpd() << "\n";

--- a/app/src/game/pgn/pgn_builder.cpp
+++ b/app/src/game/pgn/pgn_builder.cpp
@@ -82,7 +82,7 @@ PgnBuilder::PgnBuilder(const config::Pgn &pgn_config, const MatchData &match, st
         const auto last     = std::next(it) == match_.moves.end();
         const auto move_str = addMove(board, *it, move_number, n_dots, illegal, last);
 
-        board.makeMove(chess::uci::uciToMove(board, it->move));
+        board.makeMove<true>(chess::uci::uciToMove(board, it->move));
 
         move_number++;
 

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -82,7 +82,7 @@ Match::Match(const book::Opening& opening)
 
     const auto insert_move = [&](const auto& opening_move) {
         const auto move = uci::moveToUci(opening_move, board_.chess960());
-        board_.makeMove(opening_move);
+        board_.makeMove<true>(opening_move);
 
         return MoveData(move, "0.00", 0, 0, 0, 0, 0, true, true);
     };
@@ -360,7 +360,7 @@ bool Match::playMove(Player& us, Player& them) {
         return false;
     }
 
-    board_.makeMove(move);
+    board_.makeMove<true>(move);
 
     // CuteChess uses plycount/2 for its movenumber, which is wrong for epd books as it doesnt take
     // into account the fullmove counter of the starting FEN, leading to different behavior between
@@ -528,7 +528,7 @@ void Match::verifyPvLines(const Player& us) {
                 break;
             }
 
-            board.makeMove(uci::uciToMove(board, *it_start));
+            board.makeMove<true>(uci::uciToMove(board, *it_start));
 
             it_start++;
         }


### PR DESCRIPTION
fixes the issue where
```
[Variant "From Position"]
[FEN "6k1/1p2p1rp/rP1pR3/2pP1pP1/p1P2P1P/R5K1/8/8 b - - 0 1"]

1... h5 2. Rh6 Rh7 3. Re6 Rg7 4. Rh6 Rh7 5. Re6 Rg7
```

is correctly adjudicated as a threefold repetition.