### PR TITLE
fix: pgn timecontrol formatting for 0 initial time

### DIFF
--- a/app/src/time/timecontrol.cpp
+++ b/app/src/time/timecontrol.cpp
@@ -70,7 +70,7 @@ std::ostream &operator<<(std::ostream &os, const TimeControl &tc) {
 
     if (tc.limits_.moves > 0) os << tc.limits_.moves << "/";
 
-    if (tc.limits_.time > 0) os << (tc.limits_.time / 1000.0);
+    if (tc.limits_.time + tc.limits_.increment > 0) os << (tc.limits_.time / 1000.0);
 
     if (tc.limits_.increment > 0) os << "+" << (tc.limits_.increment / 1000.0);
 

--- a/app/tests/pgn_builder_test.cpp
+++ b/app/tests/pgn_builder_test.cpp
@@ -168,6 +168,50 @@ Nf6 {+10.15/18 1.821s engine1 got checkmated} 0-1
         CHECK(pgn_builder.get() == expected);
     }
 
+    TEST_CASE("PGN Creation TC") {
+        MatchData match_data;
+        match_data.players.black.config.name                = "engine1";
+        match_data.players.black.color                      = chess::Color::BLACK;
+        match_data.players.black.result                     = chess::GameResult::NONE;
+        match_data.players.black.config.limit.tc.time       = 0;
+        match_data.players.black.config.limit.tc.increment  = 5;
+
+        match_data.players.white.config.name                = "engine2";
+        match_data.players.white.color                      = chess::Color::WHITE;
+        match_data.players.white.result                     = chess::GameResult::NONE;
+        match_data.players.white.config.limit.tc.time       = 1;
+        match_data.players.white.config.limit.tc.increment  = 5;
+
+        match_data.moves = {MoveData("e8g8", "+1.00", 1321, 15, 4, 0, 0), MoveData("e1g1", "+1.23", 430, 15, 3, 0, 0),
+                            MoveData("a6c5", "+1.45", 310, 16, 24, 0, 0)};
+
+        match_data.fen = "r2qk2r/1bpp2pp/n3pn2/p2P1p2/1bP5/2N1BNP1/1PQ1PPBP/R3K2R b KQkq - 0 1";
+
+        match_data.reason = "aborted";
+
+        config::Pgn pgn_config;
+        pgn_config.site = "localhost";
+
+        std::string expected = R"([Event "Fastchess Tournament"]
+[Site "localhost"]
+[Round "1"]
+[White "engine2"]
+[Black "engine1"]
+[Result "*"]
+[SetUp "1"]
+[FEN "r2qk2r/1bpp2pp/n3pn2/p2P1p2/1bP5/2N1BNP1/1PQ1PPBP/R3K2R b KQkq - 0 1"]
+[PlyCount "3"]
+[WhiteTimeControl "1+5"]
+[BlackTimeControl "0+5"]
+
+1... O-O {+1.00/15 1.321s} 2. O-O {+1.23/15 0.430s} Nc5 {+1.45/16 0.310s aborted} *
+
+)";
+
+        pgn::PgnBuilder pgn_builder = pgn::PgnBuilder(pgn_config, match_data, 1);
+        CHECK(pgn_builder.get() == expected);
+    }
+
     TEST_CASE("PGN Creation Multiple Fixed Time per Move") {
         MatchData match_data;
         match_data.players.black.config.name                = "engine1";

--- a/app/tests/pgn_builder_test.cpp
+++ b/app/tests/pgn_builder_test.cpp
@@ -201,8 +201,8 @@ Nf6 {+10.15/18 1.821s engine1 got checkmated} 0-1
 [SetUp "1"]
 [FEN "r2qk2r/1bpp2pp/n3pn2/p2P1p2/1bP5/2N1BNP1/1PQ1PPBP/R3K2R b KQkq - 0 1"]
 [PlyCount "3"]
-[WhiteTimeControl "1+5"]
-[BlackTimeControl "0+5"]
+[WhiteTimeControl "0.001+0.005"]
+[BlackTimeControl "0+0.005"]
 
 1... O-O {+1.00/15 1.321s} 2. O-O {+1.23/15 0.430s} Nc5 {+1.45/16 0.310s aborted} *
 


### PR DESCRIPTION
fix case where `tc=0+inc` is displayed as `[TimeContol "+inc"]` in pgn