### PR TITLE
refactor: match generator

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -48,6 +48,8 @@ void parseValue(const std::vector<std::string> &params, T &value) {
         value = std::stod(str);
     else if constexpr (std::is_same_v<T, bool>)
         value = str == "true";
+    else if constexpr (std::is_same_v<T, std::size_t>)
+        sscanf(str.c_str(), "%zu", &value);
     else
         value = str;
 }

--- a/app/src/matchmaking/tournament/base/tournament.cpp
+++ b/app/src/matchmaking/tournament/base/tournament.cpp
@@ -31,6 +31,8 @@ BaseTournament::BaseTournament(const stats_map &results) {
     setResults(results);
 
     book_ = std::make_unique<book::OpeningBook>(config, initial_matchcount_);
+
+    generator_.setup(book_.get(), initial_matchcount_);
 }
 
 void BaseTournament::start() {
@@ -119,6 +121,8 @@ void BaseTournament::playGame(const GamePair<EngineConfiguration, EngineConfigur
         Logger::trace<true>("Game {} finished with result {}", game_id, result);
 
         finish({match_data}, match_data.reason, {white_engine.get(), black_engine.get()});
+
+        startNext();
     }
 }
 

--- a/app/src/matchmaking/tournament/base/tournament.hpp
+++ b/app/src/matchmaking/tournament/base/tournament.hpp
@@ -8,6 +8,7 @@
 #include <globals/globals.hpp>
 #include <matchmaking/output/output.hpp>
 #include <matchmaking/scoreboard.hpp>
+#include <matchmaking/tournament/generator.hpp>
 #include <types/tournament.hpp>
 #include <util/cache.hpp>
 #include <util/file_writer.hpp>
@@ -33,6 +34,7 @@ class BaseTournament {
     }
 
     virtual void start();
+    virtual void startNext() = 0;
 
     [[nodiscard]] stats_map getResults() noexcept { return scoreboard_.getResults(); }
 
@@ -69,6 +71,8 @@ class BaseTournament {
     // play one game and write it to the pgn file
     void playGame(const GamePair<EngineConfiguration, EngineConfiguration> &configs, start_callback start,
                   finished_callback finish, const pgn::Opening &opening, std::size_t round_id, std::size_t game_id);
+
+    MatchGenerator generator_;
 
     std::unique_ptr<IOutput> output_;
     std::unique_ptr<affinity::AffinityManager> cores_;

--- a/app/src/matchmaking/tournament/generator.hpp
+++ b/app/src/matchmaking/tournament/generator.hpp
@@ -42,8 +42,8 @@ class MatchGenerator {
     std::size_t engine_configs_size;
     int offset_;
 
-    auto games  = config::TournamentConfig.get().games;
-    auto rounds = config::TournamentConfig.get().rounds;
+    std::size_t games  = config::TournamentConfig.get().games;
+    std::size_t rounds = config::TournamentConfig.get().rounds;
 
     void advance() {
         if (++g >= games) {

--- a/app/src/matchmaking/tournament/generator.hpp
+++ b/app/src/matchmaking/tournament/generator.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <config/config.hpp>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include <book/opening_book.hpp>
+
+namespace fastchess {
+
+class MatchGenerator {
+   public:
+    MatchGenerator() : i(0), j(1), k(0), g(0), engine_configs_size(config::EngineConfigs.get().size()) {}
+
+    void setup(book::OpeningBook* opening_book, int initial_matchcount) {
+        opening_book_ = opening_book;
+        offset_       = initial_matchcount / config::TournamentConfig.get().games;
+    }
+
+    std::optional<std::tuple<std::size_t, std::size_t, std::size_t, int, std::optional<std::size_t>>> next() {
+        if (i >= engine_configs_size) {
+            return std::nullopt;  // No more matches to generate
+        }
+
+        if (k >= config::TournamentConfig.get().rounds) {
+            advance();
+            return next();  // Skip to the next valid state
+        }
+
+        if (g >= config::TournamentConfig.get().games) {
+            k++;
+            g = 0;
+            return next();  // Skip to the next valid state
+        }
+
+        const auto opening = opening_book_->fetchId();
+        auto match         = std::make_tuple(i, j, k, g, opening);
+
+        g++;  // Move to the next game
+
+        return match;
+    }
+
+   private:
+    std::size_t i, j, k, g;
+    std::size_t engine_configs_size;
+    book::OpeningBook* opening_book_ = nullptr;
+    int offset_;
+
+    void advance() {
+        j++;
+        if (j >= engine_configs_size) {
+            i++;
+            j = i + 1;
+        }
+        k = offset_;
+    }
+};
+
+}  // namespace fastchess

--- a/app/src/matchmaking/tournament/generator.hpp
+++ b/app/src/matchmaking/tournament/generator.hpp
@@ -42,8 +42,8 @@ class MatchGenerator {
     std::size_t engine_configs_size;
     int offset_;
 
-    int games  = config::TournamentConfig.get().games;
-    int rounds = config::TournamentConfig.get().rounds;
+    auto games  = config::TournamentConfig.get().games;
+    auto rounds = config::TournamentConfig.get().rounds;
 
     void advance() {
         if (++g >= games) {

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -39,6 +39,10 @@ void RoundRobin::start() {
 }
 
 void RoundRobin::startNext() {
+    std::lock_guard<std::mutex> lock(game_gen_mutex_);
+
+    if (atomic::stop) return;
+
     auto match = generator_.next();
 
     if (!match) {

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
@@ -46,6 +46,7 @@ class RoundRobin : public BaseTournament {
     SPRT sprt_ = SPRT();
 
     std::mutex output_mutex_;
+    std::mutex game_gen_mutex_;
 
     // number of games to be played
     std::atomic<uint64_t> total_ = 0;

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
@@ -35,8 +35,6 @@ class RoundRobin : public BaseTournament {
     // creates the matches
     void create() override;
 
-    void createMatch(std::size_t i, std::size_t j, std::size_t round_id, int g, std::optional<std::size_t> opening_id);
-
    private:
     void createMatch(std::size_t i, std::size_t j, std::size_t round_id, int g, std::optional<std::size_t> opening_id);
 

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
@@ -29,9 +29,13 @@ class RoundRobin : public BaseTournament {
     // starts the round robin
     void start() override;
 
+    void startNext() override;
+
    protected:
     // creates the matches
     void create() override;
+
+    void createMatch(std::size_t i, std::size_t j, std::size_t round_id, int g, std::optional<std::size_t> opening_id);
 
    private:
     void createMatch(std::size_t i, std::size_t j, std::size_t round_id, int g, std::optional<std::size_t> opening_id);

--- a/app/src/types/tournament.hpp
+++ b/app/src/types/tournament.hpp
@@ -46,8 +46,8 @@ struct Tournament {
     OutputType output    = OutputType::FASTCHESS;
     int autosaveinterval = 20;
     int ratinginterval   = 10;
-    int games            = 2;
-    int rounds           = 2;
+    std::size_t games    = 2;
+    std::size_t rounds   = 2;
     bool report_penta    = true;
 #endif
 

--- a/app/src/util/threadpool.hpp
+++ b/app/src/util/threadpool.hpp
@@ -76,6 +76,8 @@ class ThreadPool {
 
     [[nodiscard]] bool getStop() { return stop_; }
 
+    [[nodiscard]] int getNumThreads() { return workers_.size(); }
+
    private:
     void work() {
         while (!stop_) {


### PR DESCRIPTION
Saves memory and for very large round numbers by lazily creating the matches after they finish.
Pictures below are from a test tournament with 2 700 000 rounds.