### PR TITLE
fix: games not continuing properly from last config savepoint

### DIFF
--- a/app/src/matchmaking/tournament/roundrobin/match_generator.hpp
+++ b/app/src/matchmaking/tournament/roundrobin/match_generator.hpp
@@ -15,6 +15,7 @@ class MatchGenerator {
         : i(0), j(1), k(0), g(0), engine_configs_size(config::EngineConfigs.get().size()) {
         opening_book_ = opening_book;
         offset_       = initial_matchcount / config::TournamentConfig.get().games;
+        k             = offset_;
     }
 
     std::optional<std::tuple<std::size_t, std::size_t, std::size_t, int, std::optional<std::size_t>>> next() {


### PR DESCRIPTION
problem seem to have occured after the matchgenerator refactor