### PR TITLE
refactor: change pgn mate score format from moves to plies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ update-fmt: ## Fetch subtree fmt
 	git subtree pull --prefix=app/third_party/fmt https://github.com/fmtlib/fmt.git master --squash
 	@echo "Done."
 
-.PHONY:
+.PHONY: all tests
 
 update-man: man ## Update man like page
 	xxd -i man | sed 's/unsigned char/inline char/g' | sed 's/unsigned int/inline unsigned int/g' > temp.hpp

--- a/app/Makefile
+++ b/app/Makefile
@@ -47,7 +47,8 @@ SRC_FILES_TEST   := \
 	$(TESTDIR)/player.cpp \
 	$(TESTDIR)/scoreboard_test.cpp \
 	$(TESTDIR)/sprt_test.cpp \
-	$(TESTDIR)/uci_engine_test.cpp
+	$(TESTDIR)/uci_engine_test.cpp \
+	$(TESTDIR)/match_test.cpp
 
 # Only used for formatting
 HEADERS := $(shell find $(SRCDIR) -name "*.hpp") $(shell find $(TESTDIR) -maxdepth 1 -name "*.hpp")

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -53,7 +53,9 @@ void Match::addMoveData(const Player& player, int64_t measured_time_ms, int64_t 
         ss << (move_data.score >= 0 ? '+' : '-');
         ss << std::fixed << std::setprecision(2) << (float(std::abs(move_data.score)) / 100);
     } else if (score_type == engine::ScoreType::MATE) {
-        ss << (move_data.score > 0 ? "+M" : "-M") << std::to_string(std::abs(move_data.score));
+        uint64_t plies = board_.sideToMove() == Chess::Color::WHITE ? std::abs(move_data.score) * 2 
+                                                                    : std::abs(move_data.score) * 2 - 1;
+        ss << (move_data.score > 0 ? "+M" : "-M") << std::to_string(plies);
     } else {
         ss << "ERR";
     }

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -53,8 +53,8 @@ void Match::addMoveData(const Player& player, int64_t measured_time_ms, int64_t 
         ss << (move_data.score >= 0 ? '+' : '-');
         ss << std::fixed << std::setprecision(2) << (float(std::abs(move_data.score)) / 100);
     } else if (score_type == engine::ScoreType::MATE) {
-        uint64_t plies = board_.sideToMove() == chess::Color::WHITE ? std::abs(move_data.score) * 2 
-                                                                    : std::abs(move_data.score) * 2 - 1;
+        uint64_t plies = board_.sideToMove() == move_data.score > 0 ? std::abs(move_data.score) * 2 - 1
+                                                                    : std::abs(move_data.score) * 2;
         ss << (move_data.score > 0 ? "+M" : "-M") << std::to_string(plies);
     } else {
         ss << "ERR";

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -23,6 +23,22 @@ using clock = chrono::high_resolution_clock;
 using namespace std::literals;
 using namespace chess;
 
+std::string Match::convertScoreToString(int score, engine::ScoreType score_type) {
+    std::stringstream ss;
+
+    if (score_type == engine::ScoreType::CP) {
+        ss << (score >= 0 ? '+' : '-');
+        ss << std::fixed << std::setprecision(2) << (float(std::abs(score)) / 100);
+    } else if (score_type == engine::ScoreType::MATE) {
+        uint64_t plies = score > 0 ? score * 2 - 1 : score * -2;
+        ss << (score > 0 ? "+M" : "-M") << std::to_string(plies);
+    } else {
+        ss << "ERR";
+    }
+
+    return ss.str();
+}
+
 void Match::addMoveData(const Player& player, int64_t measured_time_ms, int64_t timeleft, bool legal) {
     const auto move    = player.engine.bestmove() ? *player.engine.bestmove() : "<none>";
     MoveData move_data = MoveData(move, "0.00", measured_time_ms, 0, 0, 0, 0, legal);
@@ -46,21 +62,7 @@ void Match::addMoveData(const Player& player, int64_t measured_time_ms, int64_t 
     move_data.score    = player.engine.lastScore();
     move_data.timeleft = timeleft;
 
-    // Missing elements default to 0
-    std::stringstream ss;
-
-    if (score_type == engine::ScoreType::CP) {
-        ss << (move_data.score >= 0 ? '+' : '-');
-        ss << std::fixed << std::setprecision(2) << (float(std::abs(move_data.score)) / 100);
-    } else if (score_type == engine::ScoreType::MATE) {
-        uint64_t plies = move_data.score > 0 ? move_data.score * 2 - 1
-                                             : move_data.score * -2;
-        ss << (move_data.score > 0 ? "+M" : "-M") << std::to_string(plies);
-    } else {
-        ss << "ERR";
-    }
-
-    move_data.score_string = ss.str();
+    move_data.score_string = Match::convertScoreToString(move_data.score, score_type);
 
     verifyPvLines(player);
 

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -53,8 +53,8 @@ void Match::addMoveData(const Player& player, int64_t measured_time_ms, int64_t 
         ss << (move_data.score >= 0 ? '+' : '-');
         ss << std::fixed << std::setprecision(2) << (float(std::abs(move_data.score)) / 100);
     } else if (score_type == engine::ScoreType::MATE) {
-        uint64_t plies = board_.sideToMove() == move_data.score > 0 ? std::abs(move_data.score) * 2 - 1
-                                                                    : std::abs(move_data.score) * 2;
+        uint64_t plies = move_data.score > 0 ? std::abs(move_data.score) * 2 - 1
+                                             : std::abs(move_data.score) * 2;
         ss << (move_data.score > 0 ? "+M" : "-M") << std::to_string(plies);
     } else {
         ss << "ERR";

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -53,8 +53,8 @@ void Match::addMoveData(const Player& player, int64_t measured_time_ms, int64_t 
         ss << (move_data.score >= 0 ? '+' : '-');
         ss << std::fixed << std::setprecision(2) << (float(std::abs(move_data.score)) / 100);
     } else if (score_type == engine::ScoreType::MATE) {
-        uint64_t plies = move_data.score > 0 ? std::abs(move_data.score) * 2 - 1
-                                             : std::abs(move_data.score) * 2;
+        uint64_t plies = move_data.score > 0 ? move_data.score * 2 - 1
+                                             : move_data.score * -2;
         ss << (move_data.score > 0 ? "+M" : "-M") << std::to_string(plies);
     } else {
         ss << "ERR";

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -53,7 +53,7 @@ void Match::addMoveData(const Player& player, int64_t measured_time_ms, int64_t 
         ss << (move_data.score >= 0 ? '+' : '-');
         ss << std::fixed << std::setprecision(2) << (float(std::abs(move_data.score)) / 100);
     } else if (score_type == engine::ScoreType::MATE) {
-        uint64_t plies = board_.sideToMove() == Chess::Color::WHITE ? std::abs(move_data.score) * 2 
+        uint64_t plies = board_.sideToMove() == chess::Color::WHITE ? std::abs(move_data.score) * 2 
                                                                     : std::abs(move_data.score) * 2 - 1;
         ss << (move_data.score > 0 ? "+M" : "-M") << std::to_string(plies);
     } else {

--- a/app/src/matchmaking/match/match.hpp
+++ b/app/src/matchmaking/match/match.hpp
@@ -116,6 +116,8 @@ class Match {
 
     [[nodiscard]] bool isStallOrDisconnect() const noexcept { return stall_or_disconnect_; }
 
+    static std::string convertScoreToString(int score, engine::ScoreType score_type);
+
    private:
     // returns the reason and the result of the game, different order than chess lib function
     [[nodiscard]] std::pair<chess::GameResultReason, chess::GameResult> isGameOver() const;

--- a/app/tests/match_test.cpp
+++ b/app/tests/match_test.cpp
@@ -10,6 +10,8 @@ TEST_SUITE("Match Test") {
         CHECK(Match::convertScoreToString(-100, engine::ScoreType::CP) == "-1.00");
         CHECK(Match::convertScoreToString(100, engine::ScoreType::MATE) == "+M199");
         CHECK(Match::convertScoreToString(-100, engine::ScoreType::MATE) == "-M200");
+        CHECK(Match::convertScoreToString(1, engine::ScoreType::MATE) == "+M1");
+        CHECK(Match::convertScoreToString(-1, engine::ScoreType::MATE) == "-M2");
     }
 }
 }  // namespace fastchess

--- a/app/tests/match_test.cpp
+++ b/app/tests/match_test.cpp
@@ -1,0 +1,15 @@
+#include <matchmaking/match/match.hpp>
+
+#include "doctest/doctest.hpp"
+
+namespace fastchess {
+TEST_SUITE("Match Test") {
+    TEST_CASE("convertScoreToString") {
+        CHECK(Match::convertScoreToString(0, engine::ScoreType::CP) == "+0.00");
+        CHECK(Match::convertScoreToString(100, engine::ScoreType::CP) == "+1.00");
+        CHECK(Match::convertScoreToString(-100, engine::ScoreType::CP) == "-1.00");
+        CHECK(Match::convertScoreToString(100, engine::ScoreType::MATE) == "+M199");
+        CHECK(Match::convertScoreToString(-100, engine::ScoreType::MATE) == "-M200");
+    }
+}
+}  // namespace fastchess


### PR DESCRIPTION
i think this is the correct conversion?
based on SF's `auto m = (mate.plies > 0 ? (mate.plies + 1) : mate.plies) / 2;`