### PR TITLE
fix: missing newline between printElo and printSPRT

### DIFF
--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -57,7 +57,7 @@ class Fastchess : public IOutput {
             result += fmt::format("\n{}", formatPentaStats(stats, WLDDRatio));
         }
 
-        return result;
+        return result + "\n";
     }
 
     std::string printSprt(const SPRT& sprt, const Stats& stats) override {
@@ -67,7 +67,7 @@ class Fastchess : public IOutput {
             return fmt::format("LLR: {:.2f} {} {}\n", llr, sprt.getBounds(), sprt.getElo());
         }
 
-        return "\n";
+        return "";
     }
 
     void startGame(const GamePair<EngineConfiguration, EngineConfiguration>& configs, std::size_t current_game_count,


### PR DESCRIPTION
`Ptnml(0-2): [0, 0, 1, 1, 0], WL/DD Ratio: infLLR: 0.02 (-2.94, 2.94) [0.00, 5.00]`