### PR TITLE
refactor: pgn score format when cp is 0

### DIFF
--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -27,7 +27,7 @@ std::string Match::convertScoreToString(int score, engine::ScoreType score_type)
     std::stringstream ss;
 
     if (score_type == engine::ScoreType::CP) {
-        ss << (score >= 0 ? '+' : '-');
+        ss << (score > 0 ? '+' : score < 0 ? '-' : '');
         ss << std::fixed << std::setprecision(2) << (float(std::abs(score)) / 100);
     } else if (score_type == engine::ScoreType::MATE) {
         uint64_t plies = score > 0 ? score * 2 - 1 : score * -2;

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -27,7 +27,7 @@ std::string Match::convertScoreToString(int score, engine::ScoreType score_type)
     std::stringstream ss;
 
     if (score_type == engine::ScoreType::CP) {
-        ss << (score > 0 ? '+' : score < 0 ? '-' : "");
+        ss << (score > 0 ? "+" : score < 0 ? "-" : "");
         ss << std::fixed << std::setprecision(2) << (float(std::abs(score)) / 100);
     } else if (score_type == engine::ScoreType::MATE) {
         uint64_t plies = score > 0 ? score * 2 - 1 : score * -2;

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -27,7 +27,7 @@ std::string Match::convertScoreToString(int score, engine::ScoreType score_type)
     std::stringstream ss;
 
     if (score_type == engine::ScoreType::CP) {
-        ss << (score > 0 ? '+' : score < 0 ? '-' : '');
+        ss << (score > 0 ? '+' : score < 0 ? '-' : "");
         ss << std::fixed << std::setprecision(2) << (float(std::abs(score)) / 100);
     } else if (score_type == engine::ScoreType::MATE) {
         uint64_t plies = score > 0 ? score * 2 - 1 : score * -2;

--- a/app/tests/match_test.cpp
+++ b/app/tests/match_test.cpp
@@ -5,7 +5,7 @@
 namespace fastchess {
 TEST_SUITE("Match Test") {
     TEST_CASE("convertScoreToString") {
-        CHECK(Match::convertScoreToString(0, engine::ScoreType::CP) == "+0.00");
+        CHECK(Match::convertScoreToString(0, engine::ScoreType::CP) == "0.00");
         CHECK(Match::convertScoreToString(100, engine::ScoreType::CP) == "+1.00");
         CHECK(Match::convertScoreToString(-100, engine::ScoreType::CP) == "-1.00");
         CHECK(Match::convertScoreToString(100, engine::ScoreType::MATE) == "+M199");


### PR DESCRIPTION
in cutechess when cp score is 0 the pgn comment has no sign:
`Qd6 {0.00/21 0.38s}`