### PR TITLE
fix: check uci format of engine bestmove

### DIFF
--- a/app/src/matchmaking/match/match.hpp
+++ b/app/src/matchmaking/match/match.hpp
@@ -125,7 +125,8 @@ class Match {
     void setEngineCrashStatus(Player& loser, Player& winner);
     void setEngineStallStatus(Player& loser, Player& winner);
     void setEngineTimeoutStatus(Player& loser, Player& winner);
-    void setEngineIllegalMoveStatus(Player& loser, Player& winner, const std::optional<std::string>& best_move);
+    void setEngineIllegalMoveStatus(Player& loser, Player& winner, const std::optional<std::string>& best_move,
+                                    bool invalid_format = false);
 
     static bool isUciMove(const std::string& move) noexcept;
     void verifyPvLines(const Player& us);


### PR DESCRIPTION
In case the format is not matching the standard format, an illegal move will be raised.

fixes https://github.com/Disservin/fastchess/issues/705