### PR TITLE
refactor: simplify move legality check

### DIFF
--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -249,7 +249,7 @@ bool Match::playMove(Player& us, Player& them) {
     auto best_move = us.engine.bestmove();
 
     const auto move   = best_move ? uci::uciToMove(board_, *best_move) : Move::NO_MOVE;
-    const auto is_uci = isUciMove(move);
+    const auto is_uci = isUciMove(best_move.value());
     const auto legal  = isLegal(move) && is_uci;
 
     const auto timeout  = !us.updateTime(elapsed_millis);

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -249,7 +249,7 @@ bool Match::playMove(Player& us, Player& them) {
     auto best_move = us.engine.bestmove();
 
     const auto move   = best_move ? uci::uciToMove(board_, *best_move) : Move::NO_MOVE;
-    const auto is_uci = isUciMove(best_move.value());
+    const auto is_uci = isUciMove(best_move.value_or(""));
     const auto legal  = isLegal(move) && is_uci;
 
     const auto timeout  = !us.updateTime(elapsed_millis);

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -248,13 +248,9 @@ bool Match::playMove(Player& us, Player& them) {
 
     auto best_move = us.engine.bestmove();
 
-    if (best_move && !isUciMove(best_move.value())) {
-        setEngineIllegalMoveStatus(us, them, best_move, true);
-        return false;
-    }
-
-    const auto move  = best_move ? uci::uciToMove(board_, *best_move) : Move::NO_MOVE;
-    const auto legal = isLegal(move);
+    const auto move   = best_move ? uci::uciToMove(board_, *best_move) : Move::NO_MOVE;
+    const auto is_uci = isUciMove(move);
+    const auto legal  = isLegal(move) && is_uci;
 
     const auto timeout  = !us.updateTime(elapsed_millis);
     const auto timeleft = us.getTimeControl().getTimeLeft();
@@ -279,7 +275,7 @@ bool Match::playMove(Player& us, Player& them) {
 
     // illegal move
     if (!legal) {
-        setEngineIllegalMoveStatus(us, them, best_move);
+        setEngineIllegalMoveStatus(us, them, best_move, !is_uci);
         return false;
     }
 


### PR DESCRIPTION
reduce calls to setEngineIllegalMoveStatus function