### PR TITLE
fix: posix working directory for new c libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ app/coverage
 
 **/*.gcda
 **/*.gcno
+
+test
+test.c

--- a/app/Makefile
+++ b/app/Makefile
@@ -172,6 +172,15 @@ ifeq ($(ZLIB), true)
 	LDFLAGS += -lz
 endif
 
+include ./compatability/spawn-check.mk
+
+ifeq ($(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR),1)
+    CXXFLAGS += -DHAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR
+endif
+ifeq ($(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP),1)
+    CXXFLAGS += -DHAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP
+endif
+
 OBJECTS   := $(patsubst %.cpp,$(BUILDDIR)/%.o,$(SRC_FILES))
 DEPENDS   := $(patsubst %.cpp,$(BUILDDIR)/%.d,$(SRC_FILES))
 

--- a/app/compatability/spawn-check.mk
+++ b/app/compatability/spawn-check.mk
@@ -1,12 +1,12 @@
 HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR := $(shell \
-    echo '#include <spawn.h>' > test.c && \
+    echo "#include <spawn.h>" > test.c && \
     echo 'int main(){return posix_spawn_file_actions_addchdir(0,0);}' >> test.c && \
     if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi && \
     rm -f test.c test)
 
 ifeq ($(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR),0)
 	HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP := $(shell \
-		echo '#include <spawn.h>' > test.c && \
+		echo "#include <spawn.h>" > test.c && \
 		echo 'int main(){return posix_spawn_file_actions_addchdir_np(0,0);}' >> test.c && \
 		if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi && \
 		rm -f test.c test)

--- a/app/compatability/spawn-check.mk
+++ b/app/compatability/spawn-check.mk
@@ -1,13 +1,15 @@
 HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR := $(shell \
-    echo "#include <spawn.h>" > test.c && \
-    echo 'int main(){return posix_spawn_file_actions_addchdir(0,0);}' >> test.c && \
-    if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi && \
-    rm -f test.c test)
+    printf '%s\n%s\n' \
+        '#include <spawn.h>' \
+        'int main(){return posix_spawn_file_actions_addchdir(0,0);}' > test.c \
+    && if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi \
+    && rm -f test.c test)
 
 ifeq ($(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR),0)
 	HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP := $(shell \
-		echo "#include <spawn.h>" > test.c && \
-		echo 'int main(){return posix_spawn_file_actions_addchdir_np(0,0);}' >> test.c && \
-		if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi && \
-		rm -f test.c test)
+		printf '%s\n%s\n' \
+			'#include <spawn.h>' \
+			'int main(){return posix_spawn_file_actions_addchdir_np(0,0);}' > test.c \
+		&& if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi \
+		&& rm -f test.c test)
 endif

--- a/app/compatability/spawn-check.mk
+++ b/app/compatability/spawn-check.mk
@@ -1,0 +1,13 @@
+HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR := $(shell \
+    echo '#include <spawn.h>' > test.c && \
+    echo 'int main(){return posix_spawn_file_actions_addchdir(0,0);}' >> test.c && \
+    if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi; \
+    rm -f test.c test)
+
+ifeq ($(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR),0)
+HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP := $(shell \
+	echo '#include <spawn.h>' > test.c && \
+	echo 'int main(){return posix_spawn_file_actions_addchdir_np(0,0);}' >> test.c && \
+	if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi; \
+	rm -f test.c test)
+endif

--- a/app/compatability/spawn-check.mk
+++ b/app/compatability/spawn-check.mk
@@ -1,15 +1,15 @@
+CXX := g++
+
 HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR := $(shell \
-    printf '%s\n%s\n' \
-        '#include <spawn.h>' \
-        'int main(){return posix_spawn_file_actions_addchdir(0,0);}' > test.c \
-    && if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi \
-    && rm -f test.c test)
+    echo \#include \<spawn.h\> > test.c && \
+    echo 'int main(){return posix_spawn_file_actions_addchdir(0,0);}' >> test.c && \
+    if $(CXX) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi; \
+    rm -f test.c test)
 
 ifeq ($(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR),0)
-	HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP := $(shell \
-		printf '%s\n%s\n' \
-			'#include <spawn.h>' \
-			'int main(){return posix_spawn_file_actions_addchdir_np(0,0);}' > test.c \
-		&& if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi \
-		&& rm -f test.c test)
+HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP := $(shell \
+    echo \#include \<spawn.h\> > test.c && \
+    echo 'int main(){return posix_spawn_file_actions_addchdir_np(0,0);}' >> test.c && \
+    if $(CXX) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi; \
+    rm -f test.c test)
 endif

--- a/app/compatability/spawn-check.mk
+++ b/app/compatability/spawn-check.mk
@@ -1,13 +1,13 @@
 HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR := $(shell \
     echo '#include <spawn.h>' > test.c && \
     echo 'int main(){return posix_spawn_file_actions_addchdir(0,0);}' >> test.c && \
-    if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi; \
+    if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi && \
     rm -f test.c test)
 
 ifeq ($(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR),0)
-HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP := $(shell \
-	echo '#include <spawn.h>' > test.c && \
-	echo 'int main(){return posix_spawn_file_actions_addchdir_np(0,0);}' >> test.c && \
-	if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi; \
-	rm -f test.c test)
+	HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP := $(shell \
+		echo '#include <spawn.h>' > test.c && \
+		echo 'int main(){return posix_spawn_file_actions_addchdir_np(0,0);}' >> test.c && \
+		if $(CC) test.c -o test 2>/dev/null; then echo 1; else echo 0; fi && \
+		rm -f test.c test)
 endif


### PR DESCRIPTION
Solaris, macOS 10.15, glibc 2.29, freebsd 13.01

https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_spawn_file_actions_addchdir.html

fixes https://github.com/Disservin/fastchess/issues/699