### PR TITLE
Fix build

### DIFF
--- a/app/tests/cli_test.cpp
+++ b/app/tests/cli_test.cpp
@@ -44,7 +44,7 @@ TEST_SUITE("Option Parsing Tests") {
         const auto args = cli::Args{
             "fastchess.exe",
             "-concurrency",
-            "200",
+            "20000",
         };
 
         CHECK_THROWS_WITH_AS(cli::OptionsParser{args},


### PR DESCRIPTION
causes build (and fishtest) to fail on systems with larger concurrency.