### PR TITLE
avoid informal contractions in error messages

### DIFF
--- a/app/src/cli/sanitize.cpp
+++ b/app/src/cli/sanitize.cpp
@@ -50,7 +50,7 @@ void sanitize(config::Tournament& config) {
     if (util::fd_limit::maxSystemFileDescriptorCount() <
         util::fd_limit::minFileDescriptorRequired(config.concurrency)) {
         Logger::warn(
-            "There aren't enough file descriptors available for the specified concurrency.\nPlease increase the limit "
+            "There are not enough file descriptors available for the specified concurrency.\nPlease increase the limit "
             "using ulimit -n 65536 for each shell manually or \nadjust the defaults (e.g. /etc/security/limits.conf,"
             "/etc/systemd/system.conf, and/or /etc/systemd/user.conf).\nThe maximum number of file descriptors "
             "required for this configuration is: {}",

--- a/app/src/core/logger/logger.cpp
+++ b/app/src/core/logger/logger.cpp
@@ -37,7 +37,7 @@ void Logger::openFile(const std::string &file) {
     if (!compress_) {
         log_.emplace<std::ofstream>(file.c_str(), std::ios::app);
     } else {
-        throw std::runtime_error("Compress is enabled but program wasn't compiled with zlib.");
+        throw std::runtime_error("Compress is enabled but program was not compiled with zlib.");
     }
 #endif
 

--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -80,7 +80,7 @@ process::Status UciEngine::isready(std::chrono::milliseconds threshold) {
     }
 
     if (res != process::Status::OK) {
-        Logger::trace<true>("Engine {} didn't respond to isready.", config_.name);
+        Logger::trace<true>("Engine {} did not respond to isready.", config_.name);
         Logger::warn<true>("Warning; Engine {} is not responsive.", config_.name);
 
         return res;
@@ -166,12 +166,12 @@ bool UciEngine::ucinewgame() {
 
 std::optional<std::string> UciEngine::idName() {
     if (!uci()) {
-        Logger::warn<true>("Warning; Engine {} didn't respond to uci.", config_.name);
+        Logger::warn<true>("Warning; Engine {} did not respond to uci.", config_.name);
         return std::nullopt;
     }
 
     if (!uciok()) {
-        Logger::warn<true>("Warning; Engine {} didn't respond to uci.", config_.name);
+        Logger::warn<true>("Warning; Engine {} did not respond to uci.", config_.name);
         return std::nullopt;
     }
 
@@ -188,12 +188,12 @@ std::optional<std::string> UciEngine::idName() {
 
 std::optional<std::string> UciEngine::idAuthor() {
     if (!uci()) {
-        Logger::warn<true>("Warning; Engine {} didn't respond to uci.", config_.name);
+        Logger::warn<true>("Warning; Engine {} did not respond to uci.", config_.name);
         return std::nullopt;
     }
 
     if (!uciok()) {
-        Logger::warn<true>("Warning; Engine {} didn't respond to uci.", config_.name);
+        Logger::warn<true>("Warning; Engine {} did not respond to uci.", config_.name);
         return std::nullopt;
     }
 
@@ -254,7 +254,7 @@ void UciEngine::sendSetoption(const std::string &name, const std::string &value)
     auto option = uci_options_.getOption(name);
 
     if (!option.has_value()) {
-        Logger::info<true>("Warning; {} doesn't have option {}", config_.name, name);
+        Logger::info<true>("Warning; {} does not have option {}", config_.name, name);
         return;
     }
 
@@ -310,7 +310,7 @@ bool UciEngine::start() {
     }
 
     if (!uciok(startup_time_)) {
-        Logger::warn<true>("Engine {} didn't respond to uci with uciok after startup.", config_.name);
+        Logger::warn<true>("Engine {} did not respond to uci with uciok after startup.", config_.name);
 
         return false;
     }
@@ -337,7 +337,7 @@ bool UciEngine::refreshUci() {
     }
 
     if (!ucinewgame()) {
-        Logger::trace<true>("Engine {} didn't respond to ucinewgame.", config_.name);
+        Logger::trace<true>("Engine {} did not respond to ucinewgame.", config_.name);
         return false;
     }
 

--- a/app/tests/doctest/doctest.hpp
+++ b/app/tests/doctest/doctest.hpp
@@ -5689,7 +5689,7 @@ namespace {
                                 "did NOT throw at all!")
                 << Color::Cyan << rb.m_exception << "\n";
         } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
-            s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
+            s << (rb.m_threw ? "THREW exception: " : "did not throw!") << Color::Cyan
                 << rb.m_exception << "\n";
         } else {
             s << (rb.m_threw ? "THREW exception: " :
@@ -6176,7 +6176,7 @@ namespace {
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nb,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-breaks=<bool>              "
               << Whitespace(sizePrefixDisplay*1) << "disables breakpoints in debuggers\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ns,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-skip=<bool>                "
-              << Whitespace(sizePrefixDisplay*1) << "don't skip test cases marked as skip\n";
+              << Whitespace(sizePrefixDisplay*1) << "do not skip test cases marked as skip\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "gfl, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "gnu-file-line=<bool>          "
               << Whitespace(sizePrefixDisplay*1) << ":n: vs (n): for line numbers in output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "npf, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-path-filenames=<bool>      "
@@ -6319,13 +6319,13 @@ namespace {
                   << std::fixed << tc->m_timeout << "!\n";
 
             if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
-                s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
+                s << Color::Red << "Should have failed but did not! Marking it as failed!\n";
             } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
                 s << Color::Yellow << "Failed as expected so marking it as not failed\n";
             } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
                 s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
             } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
-                s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
+                s << Color::Red << "Did not fail exactly " << tc->m_expected_failures
                   << " times so marking it as failed!\n";
             } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
                 s << Color::Yellow << "Failed exactly " << tc->m_expected_failures

--- a/app/tests/doctest/doctest.hpp
+++ b/app/tests/doctest/doctest.hpp
@@ -5689,7 +5689,7 @@ namespace {
                                 "did NOT throw at all!")
                 << Color::Cyan << rb.m_exception << "\n";
         } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
-            s << (rb.m_threw ? "THREW exception: " : "did not throw!") << Color::Cyan
+            s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
                 << rb.m_exception << "\n";
         } else {
             s << (rb.m_threw ? "THREW exception: " :
@@ -6176,7 +6176,7 @@ namespace {
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nb,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-breaks=<bool>              "
               << Whitespace(sizePrefixDisplay*1) << "disables breakpoints in debuggers\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ns,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-skip=<bool>                "
-              << Whitespace(sizePrefixDisplay*1) << "do not skip test cases marked as skip\n";
+              << Whitespace(sizePrefixDisplay*1) << "don't skip test cases marked as skip\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "gfl, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "gnu-file-line=<bool>          "
               << Whitespace(sizePrefixDisplay*1) << ":n: vs (n): for line numbers in output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "npf, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-path-filenames=<bool>      "
@@ -6319,13 +6319,13 @@ namespace {
                   << std::fixed << tc->m_timeout << "!\n";
 
             if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
-                s << Color::Red << "Should have failed but did not! Marking it as failed!\n";
+                s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
             } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
                 s << Color::Yellow << "Failed as expected so marking it as not failed\n";
             } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
                 s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
             } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
-                s << Color::Red << "Did not fail exactly " << tc->m_expected_failures
+                s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
                   << " times so marking it as failed!\n";
             } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
                 s << Color::Yellow << "Failed exactly " << tc->m_expected_failures

--- a/app/tests/e2e/e2e.sh
+++ b/app/tests/e2e/e2e.sh
@@ -88,7 +88,7 @@ OUTPUT_FILE_3=$(mktemp)
     -each tc=2+0.02s option.Hash=-16 option.Threads=2 -rounds 5 -repeat -concurrency 2 \
     -openings file=app/tests/data/openings.pgn format=pgn order=random -log file=log.txt level=info  2>&1 | tee $OUTPUT_FILE_3
 
-if ! grep -q "Warning; random_move_1 doesn't have option Threads" $OUTPUT_FILE_3; then
+if ! grep -q "Warning; random_move_1 does not have option Threads" $OUTPUT_FILE_3; then
     echo "Failed to save results."
     exit 1
 fi


### PR DESCRIPTION
As fastchess matures, maybe so should its error messages. ;)