### PR TITLE
Various QoL features and fixes

### DIFF
--- a/app/src/core/globals/globals.cpp
+++ b/app/src/core/globals/globals.cpp
@@ -61,7 +61,7 @@ void stopProcesses() {
 }
 
 void consoleHandlerAction() {
-    LOG_WARN("Received signal, stopping tournament.");
+    Logger::print<Logger::Level::WARN>("Received signal, stopping tournament.");
 
     atomic::stop = true;
 }

--- a/app/src/core/globals/globals.cpp
+++ b/app/src/core/globals/globals.cpp
@@ -1,6 +1,5 @@
 #include <core/globals/globals.hpp>
 
-#include <atomic>
 #include <cassert>
 
 #ifdef _WIN64
@@ -17,7 +16,8 @@
 namespace fastchess {
 
 namespace atomic {
-std::atomic_bool stop = false;
+std::atomic_bool stop                 = false;
+std::atomic_bool abnormal_termination = false;
 }  // namespace atomic
 
 util::ThreadVector<ProcessInformation> process_list;
@@ -63,7 +63,8 @@ void stopProcesses() {
 void consoleHandlerAction() {
     Logger::print<Logger::Level::WARN>("Received signal, stopping tournament.");
 
-    atomic::stop = true;
+    atomic::stop                 = true;
+    atomic::abnormal_termination = true;
 }
 
 #ifdef _WIN64

--- a/app/src/core/globals/globals.hpp
+++ b/app/src/core/globals/globals.hpp
@@ -1,10 +1,17 @@
 #pragma once
 
+#include <atomic>
+
 #ifdef _WIN64
 #    include <windows.h>
 #endif
 
 namespace fastchess {
+
+namespace atomic {
+extern std::atomic_bool stop;
+extern std::atomic_bool abnormal_termination;
+}  // namespace atomic
 
 /**
  * Information about the started processes (engines).

--- a/app/src/engine/process/process_posix.hpp
+++ b/app/src/engine/process/process_posix.hpp
@@ -66,10 +66,6 @@ static inline int portable_spawn_file_actions_addchdir(posix_spawn_file_actions_
 namespace fastchess {
 extern util::ThreadVector<ProcessInformation> process_list;
 
-namespace atomic {
-extern std::atomic_bool stop;
-}
-
 namespace engine::process {
 
 class Process : public IProcess {

--- a/app/src/engine/process/process_win.hpp
+++ b/app/src/engine/process/process_win.hpp
@@ -22,10 +22,6 @@ namespace fastchess {
 
 extern util::ThreadVector<ProcessInformation> process_list;
 
-namespace atomic {
-extern std::atomic_bool stop;
-}
-
 namespace engine::process {
 
 class Process : public IProcess {

--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -81,8 +81,10 @@ process::Status UciEngine::isready(std::chrono::milliseconds threshold) {
     }
 
     if (res != process::Status::OK) {
-        LOG_TRACE_THREAD("Engine {} didn't respond to isready.", config_.name);
-        Logger::print<Logger::Level::WARN>("Warning; Engine {} is not responsive.", config_.name);
+        if (!atomic::stop) {
+            LOG_TRACE_THREAD("Engine {} didn't respond to isready.", config_.name);
+            Logger::print<Logger::Level::WARN>("Warning; Engine {} is not responsive.", config_.name);
+        }
 
         return res;
     }

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -34,8 +34,6 @@ int main(int argc, char const* argv[]) {
             } else {
                 Logger::print("Tournament was interrupted.");
             }
-        } else {
-            Logger::print("Finished match");
         }
     } catch (const std::exception& e) {
         stopProcesses();
@@ -46,6 +44,8 @@ int main(int argc, char const* argv[]) {
     }
 
     stopProcesses();
+
+    Logger::print("Finished match");
 
     return atomic::abnormal_termination ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -26,6 +26,17 @@ int main(int argc, char const* argv[]) {
     try {
         auto tournament = TournamentManager();
         tournament.start(cli::Args(argc, argv));
+
+        if (atomic::abnormal_termination) {
+            if (argc > 0 && config::TournamentConfig) {
+                Logger::print("Tournament was interrupted. To resume the tournament, run: {} -config file={}", argv[0],
+                              config::TournamentConfig->config_name);
+            } else {
+                Logger::print("Tournament was interrupted.");
+            }
+        } else {
+            Logger::print("Finished match");
+        }
     } catch (const std::exception& e) {
         stopProcesses();
 
@@ -36,7 +47,5 @@ int main(int argc, char const* argv[]) {
 
     stopProcesses();
 
-    Logger::print("Finished match");
-
-    return 0;
+    return atomic::abnormal_termination ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -392,8 +392,13 @@ void Match::setEngineCrashStatus(Player& loser, Player& winner) {
     const auto name  = loser.engine.getConfig().name;
     const auto color = board_.sideToMove().longStr();
 
-    data_.termination = MatchTermination::DISCONNECT;
-    data_.reason      = color + Match::DISCONNECT_MSG;
+    if (atomic::stop) {
+        data_.termination = MatchTermination::INTERRUPT;
+        data_.reason      = Match::INTERRUPTED_MSG;
+    } else {
+        data_.termination = MatchTermination::DISCONNECT;
+        data_.reason      = color + Match::DISCONNECT_MSG;
+    }
 
     LOG_WARN_THREAD("Engine {} disconnects", name);
 }

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <regex>
 
+#include <core/globals/globals.hpp>
 #include <core/helper.hpp>
 #include <core/logger/logger.hpp>
 #include <core/time/time.hpp>
@@ -15,12 +16,6 @@ namespace chrono = std::chrono;
 using namespace std::literals;
 using namespace chess;
 using clock = chrono::steady_clock;
-
-namespace atomic {
-
-extern std::atomic_bool stop;
-
-}  // namespace atomic
 
 namespace {
 
@@ -142,7 +137,8 @@ void Match::start(engine::UciEngine& white, engine::UciEngine& black, const std:
 
     if (!white_player.engine.start()) {
         LOG_FATAL_THREAD("Failed to start engines, stopping tournament.");
-        atomic::stop = true;
+        atomic::stop                 = true;
+        atomic::abnormal_termination = true;
         return;
     }
 
@@ -152,7 +148,8 @@ void Match::start(engine::UciEngine& white, engine::UciEngine& black, const std:
 
     if (!black_player.engine.start()) {
         LOG_FATAL_THREAD("Failed to start engines, stopping tournament.");
-        atomic::stop = true;
+        atomic::stop                 = true;
+        atomic::abnormal_termination = true;
         return;
     }
 

--- a/app/src/matchmaking/match/match.hpp
+++ b/app/src/matchmaking/match/match.hpp
@@ -192,5 +192,6 @@ class Match {
     inline static constexpr char TIMEOUT_MSG[]              = /*.. */ " loses on time";
     inline static constexpr char DISCONNECT_MSG[]           = /*.. */ " disconnects";
     inline static constexpr char STALL_MSG[]                = /*.. */ "'s connection stalls";
+    inline static constexpr char INTERRUPTED_MSG[]          = "Game interrupted";
 };
 }  // namespace fastchess

--- a/app/src/matchmaking/output/output.hpp
+++ b/app/src/matchmaking/output/output.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <cli/cli.hpp>
@@ -53,7 +54,7 @@ class IOutput {
                          const std::string& annotation, std::size_t id) = 0;
 
     // Print tournament end.
-    virtual void endTournament() = 0;
+    virtual void endTournament(std::string_view terminationMessage = "") = 0;
 
     virtual OutputType getType() const = 0;
 

--- a/app/src/matchmaking/output/output_cutechess.hpp
+++ b/app/src/matchmaking/output/output_cutechess.hpp
@@ -101,7 +101,9 @@ class Cutechess : public IOutput {
                   << std::flush;
     }
 
-    void endTournament() override { std::cout << "Tournament finished" << std::endl; }
+    void endTournament(std::string_view /*terminationMessage*/ = "") override {
+        std::cout << "Tournament finished" << std::endl;
+    }
 
     OutputType getType() const override { return OutputType::CUTECHESS; }
 };

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -90,7 +90,13 @@ class Fastchess : public IOutput {
                   << std::flush;
     }
 
-    void endTournament() override { std::cout << "Tournament finished" << std::endl; }
+    void endTournament(std::string_view terminationMessage = "") override {
+        if (!terminationMessage.empty()) {
+            std::cout << terminationMessage << std::endl;
+        } else {
+            std::cout << "Tournament finished" << std::endl;
+        }
+    }
 
     OutputType getType() const override { return OutputType::FASTCHESS; }
 

--- a/app/src/matchmaking/output/output_fastchess.hpp
+++ b/app/src/matchmaking/output/output_fastchess.hpp
@@ -70,7 +70,8 @@ class Fastchess : public IOutput {
         if (sprt.isEnabled()) {
             double llr = sprt.getLLR(stats, report_penta_);
 
-            return fmt::format("LLR: {:.2f} {} {}\n", llr, sprt.getBounds(), sprt.getElo());
+            return fmt::format("LLR: {:.2f} ({:.1f}%) {} {}\n", llr, sprt.getFraction(llr) * 100., sprt.getBounds(),
+                               sprt.getElo());
         }
 
         return "";

--- a/app/src/matchmaking/sprt/sprt.cpp
+++ b/app/src/matchmaking/sprt/sprt.cpp
@@ -305,9 +305,9 @@ SPRTResult SPRT::getResult(double llr) const noexcept {
     if (!enabled_) return SPRT_CONTINUE;
 
     if (llr >= upper_)
-        return SPRT_H0;
-    else if (llr <= lower_)
         return SPRT_H1;
+    else if (llr <= lower_)
+        return SPRT_H0;
     return SPRT_CONTINUE;
 }
 

--- a/app/src/matchmaking/sprt/sprt.cpp
+++ b/app/src/matchmaking/sprt/sprt.cpp
@@ -81,6 +81,14 @@ double SPRT::getLLR(const Stats& stats, bool penta) const noexcept {
     return getLLR(stats.wins, stats.draws, stats.losses);
 }
 
+double SPRT::getFraction(const double llr) const noexcept {
+    if (llr >= 0) {
+        return llr / upper_;
+    } else {
+        return -llr / lower_;
+    }
+}
+
 double SPRT::getLLR(int win, int draw, int loss) const noexcept {
     if (!enabled_) return 0.0;
 

--- a/app/src/matchmaking/sprt/sprt.hpp
+++ b/app/src/matchmaking/sprt/sprt.hpp
@@ -19,6 +19,8 @@ class SPRT {
 
     [[nodiscard]] double getLLR(const Stats& stats, bool penta) const noexcept;
 
+    [[nodiscard]] double getFraction(double llr) const noexcept;
+
     [[nodiscard]] SPRTResult getResult(double llr) const noexcept;
 
     [[nodiscard]] std::string getBounds() const noexcept;

--- a/app/src/matchmaking/tournament/base/tournament.cpp
+++ b/app/src/matchmaking/tournament/base/tournament.cpp
@@ -9,6 +9,7 @@
 
 #include <affinity/affinity_manager.hpp>
 #include <core/filesystem/file_writer.hpp>
+#include <core/globals/globals.hpp>
 #include <core/logger/logger.hpp>
 #include <core/memory/cache.hpp>
 #include <core/threading/threadpool.hpp>
@@ -24,10 +25,6 @@
 #include <types/tournament.hpp>
 
 namespace fastchess {
-
-namespace atomic {
-extern std::atomic_bool stop;
-}  // namespace atomic
 
 BaseTournament::BaseTournament(const stats_map &results) {
     const auto &config = *config::TournamentConfig;
@@ -99,9 +96,7 @@ void BaseTournament::saveJson() {
     jsonfile["engines"]             = *config::EngineConfigs;
     jsonfile["stats"]               = getResults();
 
-    auto filename = config.config_name.empty() ? "config.json" : config.config_name;
-
-    std::ofstream file(filename);
+    std::ofstream file(config.config_name);
     file << std::setw(4) << jsonfile << std::endl;
 
     LOG_TRACE("Saved results to.");
@@ -145,6 +140,8 @@ void BaseTournament::playGame(const GamePair<EngineConfiguration, EngineConfigur
                 Logger::print<Logger::Level::WARN>(
                     "Game {} stalled / disconnected and no recover option set for engine, stopping tournament.",
                     game_id);
+
+                atomic::abnormal_termination = true;
             }
             return;
         }

--- a/app/src/matchmaking/tournament/base/tournament.cpp
+++ b/app/src/matchmaking/tournament/base/tournament.cpp
@@ -141,8 +141,11 @@ void BaseTournament::playGame(const GamePair<EngineConfiguration, EngineConfigur
         LOG_WARN_THREAD("Game {} between {} and {} stalled / disconnected", game_id, white_name, black_name);
 
         if (!config.recover) {
-            LOG_WARN_THREAD("No recover option set for engine, stopping tournament.");
-            atomic::stop = true;
+            if (!atomic::stop.exchange(true)) {
+                Logger::print<Logger::Level::WARN>(
+                    "Game {} stalled / disconnected and no recover option set for engine, stopping tournament.",
+                    game_id);
+            }
             return;
         }
 

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -142,8 +142,7 @@ void RoundRobin::updateSprtStatus(const std::vector<EngineConfiguration>& engine
         atomic::stop = true;
 
         const std::string terminationMessage =
-            fmt::format("SPRT test finished: {} {} - {} was accepted", sprt_.getBounds(), sprt_.getElo(),
-                        sprtResult == SPRT_H0 ? "H0" : "H1");
+            fmt::format("SPRT ({}) completed - {} was accepted", sprt_.getElo(), sprtResult == SPRT_H0 ? "H0" : "H1");
 
         Logger::info(terminationMessage);
 

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -139,12 +139,15 @@ void RoundRobin::updateSprtStatus(const std::vector<EngineConfiguration>& engine
         LOG_TRACE("SPRT test finished, stopping tournament.");
         atomic::stop = true;
 
-        Logger::info("SPRT test finished: {} {}", sprt_.getBounds(), sprt_.getElo());
+        const std::string terminationMessage =
+            fmt::format("SPRT test finished: {} {}", sprt_.getBounds(), sprt_.getElo());
+
+        Logger::info(terminationMessage);
 
         output_->printResult(stats, engine_configs[0].name, engine_configs[1].name);
         output_->printInterval(sprt_, stats, engine_configs[0].name, engine_configs[1].name, engines,
                                config::TournamentConfig->opening.file, scoreboard_);
-        output_->endTournament();
+        output_->endTournament(terminationMessage);
     }
 }
 

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -135,12 +135,15 @@ void RoundRobin::updateSprtStatus(const std::vector<EngineConfiguration>& engine
     const auto stats = scoreboard_.getStats(engine_configs[0].name, engine_configs[1].name);
     const auto llr   = sprt_.getLLR(stats, config::TournamentConfig->report_penta);
 
-    if (sprt_.getResult(llr) != SPRT_CONTINUE || match_count_ == final_matchcount_) {
+    const auto sprtResult = sprt_.getResult(llr);
+
+    if (sprtResult != SPRT_CONTINUE || match_count_ == final_matchcount_) {
         LOG_TRACE("SPRT test finished, stopping tournament.");
         atomic::stop = true;
 
         const std::string terminationMessage =
-            fmt::format("SPRT test finished: {} {}", sprt_.getBounds(), sprt_.getElo());
+            fmt::format("SPRT test finished: {} {} - {} was accepted", sprt_.getBounds(), sprt_.getElo(),
+                        sprtResult == SPRT_H0 ? "H0" : "H1");
 
         Logger::info(terminationMessage);
 

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.hpp
@@ -6,6 +6,7 @@
 
 #include <affinity/affinity_manager.hpp>
 #include <core/filesystem/file_writer.hpp>
+#include <core/globals/globals.hpp>
 #include <core/memory/cache.hpp>
 #include <core/rand.hpp>
 #include <core/threading/threadpool.hpp>
@@ -19,10 +20,6 @@
 #include <matchmaking/tournament/base/tournament.hpp>
 
 namespace fastchess {
-
-namespace atomic {
-extern std::atomic_bool stop;
-}  // namespace atomic
 
 class RoundRobin : public BaseTournament {
    public:

--- a/app/src/matchmaking/tournament/tournament_manager.cpp
+++ b/app/src/matchmaking/tournament/tournament_manager.cpp
@@ -20,7 +20,9 @@ TournamentManager::~TournamentManager() {
     // Note: this is safe to call even if initSyzygy() was not called.
     tearDownSyzygy();
 
-    atomic::stop = true;
+    if (!atomic::stop.exchange(true)) {
+        atomic::abnormal_termination = true;
+    }
     LOG_TRACE("~TournamentManager()");
 }
 

--- a/app/src/matchmaking/tournament/tournament_manager.cpp
+++ b/app/src/matchmaking/tournament/tournament_manager.cpp
@@ -20,9 +20,7 @@ TournamentManager::~TournamentManager() {
     // Note: this is safe to call even if initSyzygy() was not called.
     tearDownSyzygy();
 
-    if (!atomic::stop.exchange(true)) {
-        atomic::abnormal_termination = true;
-    }
+    atomic::stop = true;
     LOG_TRACE("~TournamentManager()");
 }
 

--- a/app/src/types/tournament.hpp
+++ b/app/src/types/tournament.hpp
@@ -26,7 +26,7 @@ struct Tournament {
 
     Sprt sprt = {};
 
-    std::string config_name;
+    std::string config_name = "config.json";
 
     DrawAdjudication draw          = {};
     ResignAdjudication resign      = {};


### PR DESCRIPTION
A bunch of small quality-of-life features and fixes:
 - Print a message if the SPRT has completed, and indicate whether H0 or H1 was accepted. Previously, the match would just end with no clear indication of why (unless you had logging enabled and reviewed the log). Ex.:
    ```
    SPRT ([0.00, 100.00]) completed - H0 was accepted
    ```
 - Print diagnostic messages for the following abnormal terminations: signal received, engine not responsive. Previously, these were only log messages, now they also show in the terminal. Ex.:
    ```
    Received signal, stopping tournament.
    ```
 - In case of an abnormal termination (such as SIGINT or an engine crashing without `-recover`): instead of printing 'finished match', print a message indicating that the tournament was interrupted, and automatically generate the command needed to resume the tournament if desired. Also set exit code to 1. Ex.:
    ```
    Tournament was interrupted. To resume the tournament, run: C:\Git\fastchess\fastchess.exe -config 
    file=C:\Chess\fastchessConfig.json
    ```
    Or:
    ```
    Tournament was interrupted. To resume the tournament, run: ./fastchess -config file=config.json
    ```
 - If the tournament is forcefully stopped by fastchess (by setting `atomic::stop` to `true`), don't mark engines as stalled/disconnected. (Note that in such a case `Process::readOutput` always returns an error state, so the match code will think the engine has stalled/disconnected even if the process is stilly healthy; we don't want to surface that as a crash to the user.)
 - Print the percentage of the LLR relative to the SPRT bounds, similar to cutechess. Ex.:
    ```
    LLR: -0.30 (-10.2%) (-2.94, 2.94) [0.00, 100.00]
    ```
 - Fix return value of `SPRT::getLLR` (H0 vs H1 didn't matter previously as it was only compared to CONTINUE).

More complete example for SPRT, to show how some of it fits together:
```
--------------------------------------------------
Results of sf_1 vs sf_2 (6 plies - 8 plies, 1t, 16MB, UHO_4060_v2.epd):
Elo: -398.19 +/- 82.31, nElo: -591.37 +/- 54.17
LOS: 0.00 %, DrawRatio: 7.59 %, PairsRatio: 0.01
Games: 158, Wins: 5, Losses: 134, Draws: 19, Points: 14.5 (9.18 %)
Ptnml(0-2): [58, 14, 6, 1, 0], WL/DD Ratio: 2.00
LLR: -2.97 (-100.8%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H0 was accepted
Finished match
```

Associated refactors:
 - `atomic::stop` (and the new `atomic::abnormal_termination`) is now declared in globals.hpp instead of being declared ad-hoc at various sites of usage.
 - The config file path is now defaulted to config.json directly in `config::Tournament`, instead of doing that in `BaseTournament`. This allows other code (such as the diagnostic in main.cpp) to reference `config::Tournament::config_name` directly without having to worry about defaulting it if it's empty.