### PR TITLE
add support for gzipped books

### DIFF
--- a/app/src/game/book/epd_reader.cpp
+++ b/app/src/game/book/epd_reader.cpp
@@ -46,29 +46,34 @@ std::istream& safeGetline(std::istream& is, std::string& t) {
 namespace fastchess::book {
 
 EpdReader::EpdReader(const std::string& epd_file_path) : epd_file_(epd_file_path) {
-    std::ifstream openingFile(epd_file_);
+    bool is_gzipped = epd_file_path.size() >= 3 && epd_file_path.substr(epd_file_path.size() - 3) == ".gz";
 
-    if (!openingFile.is_open()) {
-        throw std::runtime_error("Failed to open file: " + epd_file_);
-    }
-
-    std::string line;
-    if (epd_file_.size() >= 3 && epd_file_.substr(epd_file_.size() - 3) == ".gz") {
-        openingFile.close();
+    std::unique_ptr<std::istream> input_stream;
+    if (is_gzipped) {
 #ifdef USE_ZLIB
-        igzstream input(epd_file_.c_str());
-        while (safeGetline(input, line))
-            if (!line.empty()) openings_.emplace_back(util::heap_string(line.c_str()));
+        input_stream = std::make_unique<igzstream>(epd_file_path.c_str());
+
+        if (dynamic_cast<igzstream*>(input_stream.get())->rdbuf()->is_open() == false) {
+            throw std::runtime_error("Failed to open file: " + epd_file_path);
+        }
 #else
         throw std::runtime_error("Compressed book is provided but program wasn't compiled with zlib.");
 #endif
     } else {
-        while (safeGetline(openingFile, line))
-            if (!line.empty()) openings_.emplace_back(util::heap_string(line.c_str()));
+        input_stream = std::make_unique<std::ifstream>(epd_file_path);
+
+        if (dynamic_cast<std::ifstream*>(input_stream.get())->is_open() == false) {
+            throw std::runtime_error("Failed to open file: " + epd_file_path);
+        }
+    }
+
+    std::string line;
+    while (safeGetline(*input_stream, line)) {
+        if (!line.empty()) openings_.emplace_back(util::heap_string(line.c_str()));
     }
 
     if (openings_.empty()) {
-        throw std::runtime_error("No openings found in file: " + epd_file_);
+        throw std::runtime_error("No openings found in file: " + epd_file_path);
     }
 }
 

--- a/app/src/game/book/pgn_reader.cpp
+++ b/app/src/game/book/pgn_reader.cpp
@@ -106,5 +106,6 @@ PgnReader::PgnReader(const std::string& pgn_file_path, int plies_limit)
     if (pgns_.empty()) {
         throw std::runtime_error("No openings found in file: " + file_name_);
     }
+}
 
 }  // namespace fastchess::book


### PR DESCRIPTION
This allows to specify the book names `foo.epd.gz` or `bar.pgn.gz`, and the files will be decompressed on the fly.

I find this feature very convenient, and it may allow to streamline the book handling for Fishtest in future.

If this is merged, some checks may need to be added to the CI to see that this works on all architectures (it should).

Also, it may be time to retire the `ZLIB` makefile flag and always compile with zlib support.