### PR TITLE
fix: log formatting for windows

### DIFF
--- a/app/src/core/logger/logger.cpp
+++ b/app/src/core/logger/logger.cpp
@@ -65,7 +65,11 @@ void Logger::writeToEngine(const std::string &msg, const std::string &time, cons
 
     const auto id = std::this_thread::get_id();
 
+    #ifdef _WIN32
+    auto fmt_message = fmt::format("[{:<6}] [{:>15}] <{:>3}> {} <--- {}\n", "Engine", timestamp, id, name, msg);
+    #else
     auto fmt_message = fmt::format("[{:<6}] [{:>15}] <{:>20}> {} <--- {}\n", "Engine", timestamp, id, name, msg);
+    #endif
 
     const std::lock_guard<std::mutex> lock(log_mutex_);
     std::visit([&](auto &&arg) { arg << fmt_message << std::flush; }, log_);
@@ -77,8 +81,13 @@ void Logger::readFromEngine(const std::string &msg, const std::string &time, con
         return;
     }
 
+    #ifdef _WIN32
+    auto fmt_message = fmt::format("[{:<6}] [{:>15}] <{:>3}> {}{} ---> {}\n", "Engine", time, id,
+                                   (err ? "<stderr> " : ""), name, msg);
+    #else
     auto fmt_message = fmt::format("[{:<6}] [{:>15}] <{:>20}> {}{} ---> {}\n", "Engine", time, id,
                                    (err ? "<stderr> " : ""), name, msg);
+    #endif
 
     const std::lock_guard<std::mutex> lock(log_mutex_);
     std::visit([&](auto &&arg) { arg << fmt_message << std::flush; }, log_);

--- a/app/src/core/logger/logger.hpp
+++ b/app/src/core/logger/logger.hpp
@@ -128,8 +128,12 @@ class Logger {
         /*
         label, time, thread_id, message
         */
+        #ifdef _WIN32
+        const auto fmt = "[{:<6}] [{:>15}] <{:>3}> fastchess --- {}";
+        #else
+        const auto fmt = "[{:<6}] [{:>15}] <{:>20}> fastchess --- {}";
+        #endif
 
-        const auto fmt = "[{:<6}] [{:>15}] <{:>1}> fastchess --- {}";
         auto thread_id_str = thread ? fmt::format("{}", std::this_thread::get_id()) : "";
        
         std::string fmt_message = fmt::format(fmt, label, time::datetime_precise(), thread_id_str, message);

--- a/app/src/core/logger/logger.hpp
+++ b/app/src/core/logger/logger.hpp
@@ -129,14 +129,10 @@ class Logger {
         label, time, thread_id, message
         */
 
-        const auto fmt = "[{:<6}] [{:>15}] <{:>20}> fastchess --- {}";
-        std::string fmt_message;
-
-        if constexpr (thread) {
-            fmt_message = fmt::format(fmt, label, time::datetime_precise(), std::this_thread::get_id(), message);
-        } else {
-            fmt_message = fmt::format(fmt, label, time::datetime_precise(), "", message);
-        }
+        const auto fmt = "[{:<6}] [{:>15}] <{:>1}> fastchess --- {}";
+        auto thread_id_str = thread ? fmt::format("{}", std::this_thread::get_id()) : "";
+       
+        std::string fmt_message = fmt::format(fmt, label, time::datetime_precise(), thread_id_str, message);
 
         const std::lock_guard<std::mutex> lock(log_mutex_);
         std::visit([&](auto &&arg) { arg << fmt_message << std::flush; }, log_);


### PR DESCRIPTION
on windows, thread id is a single digit number, causing the current formatting to take a lot of unecessary space
```
[INFO  ] [13:11:24.783064] <                    > fastchess --- Starting tournament...
[TRACE ] [13:11:24.783491] <                    > fastchess --- Starting round robin tournament...
[TRACE ] [13:11:24.784552] <                    > fastchess --- Starting tournament...
[TRACE ] [13:11:24.784641] <                    > fastchess --- Creating matches...
[TRACE ] [13:11:24.785256] <                   6> fastchess --- Game 4 between Engine2 and Engine1 starting
[TRACE ] [13:11:24.785317] <                   5> fastchess --- Game 2 between Engine2 and Engine1 starting
[TRACE ] [13:11:24.785387] <                   3> fastchess --- Game 3 between Engine1 and Engine2 starting
[TRACE ] [13:11:24.785517] <                   4> fastchess --- Game 1 between Engine1 and Engine2 starting
[TRACE ] [13:11:24.786194] <                   6> fastchess --- Starting engine Engine2 at Stockfish dev-20240709-362a77a3.exe
```