### PR TITLE
refactor: avoid double ucinewgame

### DIFF
--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -82,14 +82,14 @@ process::Status UciEngine::isready(std::chrono::milliseconds threshold) {
 
     if (res != process::Status::OK) {
         if (!atomic::stop) {
-            LOG_TRACE_THREAD("Engine {} didn't respond to isready.", config_.name);
-            Logger::print<Logger::Level::WARN>("Warning; Engine {} is not responsive.", config_.name);
+            LOG_TRACE_THREAD("Engine {} didn't respond to isready", config_.name);
+            Logger::print<Logger::Level::WARN>("Warning; Engine {} is not responsive", config_.name);
         }
 
         return res;
     }
 
-    LOG_TRACE_THREAD("Engine {} is {}", config_.name, "responsive.");
+    LOG_TRACE_THREAD("Engine {} is {}", config_.name, "responsive");
 
     return res;
 }
@@ -331,7 +331,7 @@ bool UciEngine::refreshUci() {
     LOG_TRACE_THREAD("Refreshing engine {}", config_.name);
 
     if (!ucinewgame()) {
-        LOG_WARN_THREAD("Engine {} failed to refresh.", config_.name);
+        LOG_WARN_THREAD("Engine {} failed to start/refresh (ucinewgame).", config_.name);
         return false;
     }
 
@@ -343,10 +343,7 @@ bool UciEngine::refreshUci() {
         sendSetoption("UCI_Chess960", "true");
     }
 
-    if (!ucinewgame()) {
-        LOG_WARN_THREAD("Engine {} didn't respond to ucinewgame.", config_.name);
-        return false;
-    }
+    LOG_TRACE_THREAD("Engine {} refreshed.", config_.name);
 
     return true;
 }

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -163,10 +163,6 @@ void Match::start(engine::UciEngine& white, engine::UciEngine& black, const std:
         return;
     }
 
-    if (atomic::stop.load()) {
-        return;
-    }
-
     if (!black_player.engine.start()) {
         LOG_FATAL_THREAD("Failed to start engines, stopping tournament.");
         atomic::stop                 = true;
@@ -174,8 +170,20 @@ void Match::start(engine::UciEngine& white, engine::UciEngine& black, const std:
         return;
     }
 
-    white_player.engine.refreshUci();
-    black_player.engine.refreshUci();
+    if (atomic::stop.load()) {
+        return;
+    }
+
+    if (!white_player.engine.refreshUci()) {
+        setEngineCrashStatus(white_player, black_player);
+    }
+
+    if (!black_player.engine.refreshUci()) {
+        setEngineCrashStatus(black_player, white_player);
+    }
+
+    // check connection
+    validConnection(white_player, black_player);
 
     white_player.engine.setCpus(cpus);
     black_player.engine.setCpus(cpus);
@@ -185,6 +193,22 @@ void Match::start(engine::UciEngine& white, engine::UciEngine& black, const std:
 
     const auto start = clock::now();
 
+    if (data_.termination == MatchTermination::None) {
+        gameLoop(first, second);
+    }
+
+    const auto end = clock::now();
+
+    data_.variant = config::TournamentConfig->variant;
+
+    data_.end_time = time::datetime_iso();
+    data_.duration = time::duration(chrono::duration_cast<chrono::seconds>(end - start));
+
+    data_.players = GamePair(MatchData::PlayerInfo{white_player.engine.getConfig(), white_player.getResult()},
+                             MatchData::PlayerInfo{black_player.engine.getConfig(), black_player.getResult()});
+}
+
+void Match::gameLoop(Player& first, Player& second) {
     try {
         while (true) {
             if (atomic::stop.load()) {
@@ -204,16 +228,6 @@ void Match::start(engine::UciEngine& white, engine::UciEngine& black, const std:
     } catch (const std::exception& e) {
         LOG_FATAL_THREAD("Match failed with exception; {}", e.what());
     }
-
-    const auto end = clock::now();
-
-    data_.variant = config::TournamentConfig->variant;
-
-    data_.end_time = time::datetime_iso();
-    data_.duration = time::duration(chrono::duration_cast<chrono::seconds>(end - start));
-
-    data_.players = GamePair(MatchData::PlayerInfo{white_player.engine.getConfig(), white_player.getResult()},
-                             MatchData::PlayerInfo{black_player.engine.getConfig(), black_player.getResult()});
 }
 
 bool Match::playMove(Player& us, Player& them) {

--- a/app/src/matchmaking/match/match.hpp
+++ b/app/src/matchmaking/match/match.hpp
@@ -134,6 +134,8 @@ class Match {
     static std::string convertScoreToString(int score, engine::ScoreType score_type);
 
    private:
+    void gameLoop(Player& first, Player& second);
+
     // returns the reason and the result of the game, different order than chess lib function
     [[nodiscard]] std::pair<chess::GameResultReason, chess::GameResult> isGameOver() const;
 

--- a/app/src/matchmaking/tournament/base/tournament.cpp
+++ b/app/src/matchmaking/tournament/base/tournament.cpp
@@ -148,8 +148,6 @@ void BaseTournament::playGame(const GamePair<EngineConfiguration, EngineConfigur
 
         // restart the engine when recover is enabled
 
-        LOG_TRACE_THREAD("Restarting engine...");
-
         if (white_engine.get()->isready() != engine::process::Status::OK) restartEngine(white_engine.get());
         if (black_engine.get()->isready() != engine::process::Status::OK) restartEngine(black_engine.get());
     }


### PR DESCRIPTION
- Remove dot from log message.
- Give more log info.
- Terminate match early if refresh/start (ucinewgame) failed.