### PR TITLE
feat: add auto logger

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -405,6 +405,8 @@ void parseLog(const std::vector<std::string> &params, ArgumentData &argument_dat
             argument_data.tournament_config.log.realtime = value == "true";
         } else if (key == "engine" && is_bool(value)) {
             argument_data.tournament_config.log.engine_coms = value == "true";
+        } else if (key == "auto_log" && is_bool(value)) {
+            argument_data.tournament_config.log.auto_log = value == "true";
         } else {
             OptionsParser::throwMissing("log", key, value);
         }

--- a/app/src/core/logger/logger.cpp
+++ b/app/src/core/logger/logger.cpp
@@ -20,6 +20,9 @@ std::atomic_bool Logger::should_log_ = false;
 std::mutex Logger::log_mutex_;
 Logger::log_file_type Logger::log_;
 bool Logger::engine_coms_ = false;
+bool Logger::auto_log_    = true;
+
+std::unordered_map<std::thread::id, std::vector<std::string>> log_buffer_;
 
 void Logger::openFile(const std::string &file) {
     if (file.empty()) {
@@ -44,6 +47,10 @@ void Logger::openFile(const std::string &file) {
 
     Logger::should_log_ = true;
 
+    if (auto_log_) {
+        should_log_ = false;
+    }
+
     // verify that the file was opened
 
     std::visit(
@@ -57,7 +64,7 @@ void Logger::openFile(const std::string &file) {
 }
 
 void Logger::writeToEngine(const std::string &msg, const std::string &time, const std::string &name) {
-    if (!should_log_ || !engine_coms_) {
+    if (!auto_log_ && (!should_log_ || !engine_coms_)) {
         return;
     }
 
@@ -71,13 +78,17 @@ void Logger::writeToEngine(const std::string &msg, const std::string &time, cons
     auto fmt_message = fmt::format("[{:<6}] [{:>15}] <{:>20}> {} <--- {}\n", "Engine", timestamp, id, name, msg);
 #endif
 
-    const std::lock_guard<std::mutex> lock(log_mutex_);
-    std::visit([&](auto &&arg) { arg << fmt_message << std::flush; }, log_);
+    if (!auto_log_) {
+        const std::lock_guard<std::mutex> lock(log_mutex_);
+        std::visit([&](auto &&arg) { arg << fmt_message << std::flush; }, log_);
+    } else {
+        auto_log(Level::INFO, fmt_message, id);
+    }
 }
 
 void Logger::readFromEngine(const std::string &msg, const std::string &time, const std::string &name, bool err,
                             std::thread::id id) {
-    if (!should_log_ || !engine_coms_) {
+    if (!auto_log_ && (!should_log_ || !engine_coms_)) {
         return;
     }
 
@@ -89,8 +100,43 @@ void Logger::readFromEngine(const std::string &msg, const std::string &time, con
                                    (err ? "<stderr> " : ""), name, msg);
 #endif
 
-    const std::lock_guard<std::mutex> lock(log_mutex_);
-    std::visit([&](auto &&arg) { arg << fmt_message << std::flush; }, log_);
+    if (!auto_log_) {
+        const std::lock_guard<std::mutex> lock(log_mutex_);
+        std::visit([&](auto &&arg) { arg << fmt_message << std::flush; }, log_);
+    } else {
+        auto_log(Level::INFO, fmt_message, id);
+    }
+}
+
+void Logger::auto_log(Level level, std::string_view message, std::thread::id id) {
+    const auto timestamp = time::datetime_precise();
+
+    auto &logs = log_buffer_[id];
+    logs.emplace_back(message);
+
+    if (level >= Level::WARN) {
+        flush_log_buffer(id);
+        clear_log_buffer(id);
+    }
+}
+
+void Logger::clear_log_buffer(std::thread::id id) {
+    auto it = log_buffer_.find(id);
+    if (it != log_buffer_.end()) {
+        it->second.clear();
+    }
+}
+
+void Logger::flush_log_buffer(std::thread::id id) {
+    auto it = log_buffer_.find(id);
+
+    if (it != log_buffer_.end()) {
+        for (const auto &msg : it->second) {
+            const std::lock_guard<std::mutex> lock(log_mutex_);
+
+            std::visit([&](auto &&arg) { arg << msg << std::flush; }, log_);
+        }
+    }
 }
 
 }  // namespace fastchess

--- a/app/src/core/logger/logger.cpp
+++ b/app/src/core/logger/logger.cpp
@@ -20,7 +20,7 @@ std::atomic_bool Logger::should_log_ = false;
 std::mutex Logger::log_mutex_;
 Logger::log_file_type Logger::log_;
 bool Logger::engine_coms_ = false;
-bool Logger::auto_log_    = true;
+bool Logger::auto_log_    = false;
 
 std::unordered_map<std::thread::id, std::vector<std::string>> log_buffer_;
 

--- a/app/src/core/logger/logger.hpp
+++ b/app/src/core/logger/logger.hpp
@@ -45,6 +45,7 @@ class Logger {
     static void setCompress(bool compress) { compress_ = compress; }
     static void openFile(const std::string &file);
     static void setEngineComs(bool engine_coms) { engine_coms_ = engine_coms; }
+    static void setAutoLog(bool auto_log) { auto_log_ = auto_log; }
 
     // Direct function calls - no file path
     template <bool thread = false, typename... T>

--- a/app/src/matchmaking/tournament/base/tournament.cpp
+++ b/app/src/matchmaking/tournament/base/tournament.cpp
@@ -107,6 +107,8 @@ void BaseTournament::playGame(const GamePair<EngineConfiguration, EngineConfigur
                               std::size_t round_id, std::size_t game_id) {
     if (atomic::stop) return;
 
+    Logger::clear_log_buffer(std::this_thread::get_id());
+
     const auto &config = *config::TournamentConfig;
     const auto rl      = config.log.realtime;
     const auto core    = util::ScopeGuard(cores_->consume());

--- a/app/src/matchmaking/tournament/tournament_manager.cpp
+++ b/app/src/matchmaking/tournament/tournament_manager.cpp
@@ -35,6 +35,7 @@ void TournamentManager::start(const cli::Args& args) {
     Logger::setCompress(config::TournamentConfig->log.compress);
     Logger::openFile(config::TournamentConfig->log.file);
     Logger::setEngineComs(config::TournamentConfig->log.engine_coms);
+    Logger::setAutoLog(config::TournamentConfig->log.auto_log);
 
     LOG_INFO("{}", cli::OptionsParser::Version);
 

--- a/app/src/types/log.hpp
+++ b/app/src/types/log.hpp
@@ -12,7 +12,8 @@ struct Log {
     bool compress       = false;
     bool realtime       = true;
     bool engine_coms    = false;
+    bool auto_log       = true;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Log, file, level, compress, realtime)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Log, file, level, compress, realtime, auto_log)
 
 }  // namespace fastchess::config

--- a/app/src/types/log.hpp
+++ b/app/src/types/log.hpp
@@ -12,7 +12,7 @@ struct Log {
     bool compress       = false;
     bool realtime       = true;
     bool engine_coms    = false;
-    bool auto_log       = true;
+    bool auto_log       = false;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Log, file, level, compress, realtime, auto_log)
 

--- a/app/tests/configs/config.json
+++ b/app/tests/configs/config.json
@@ -17,8 +17,8 @@
   },
   "tb_adjudication": {
     "syzygy_dirs": "",
-	"max_pieces": 0,
-	"ignore_50_move_rule": false,
+    "max_pieces": 0,
+    "ignore_50_move_rule": false,
     "enabled": false
   },
   "opening": {
@@ -77,7 +77,8 @@
     "file": "",
     "level": 2,
     "compress": false,
-    "realtime": true
+    "realtime": true,
+    "auto_log": false
   },
   "engines": [
     {

--- a/man.md
+++ b/man.md
@@ -167,8 +167,8 @@ The following options are available:
 
     - LEVEL:
         - trace
-        - warn (default)
         - info
+        - warn (default)
         - err
         - fatal
 

--- a/man.md
+++ b/man.md
@@ -161,7 +161,7 @@ The following options are available:
 - -srand SEED  
     Specify the seed for opening book randomization.
 
-- -log file=NAME level=LEVEL compress=(true|false) realtime=(true|false) engine=(true|false)
+- -log file=NAME level=LEVEL compress=(true|false) realtime=(true|false) engine=(true|false) auto_log=(true|false)
     Specify a log file with a specific log level. Set compress to true to gzip the file. Default is false.
     By default engine logs are disabled. Set engine to true to enable them.
 


### PR DESCRIPTION
This stores logs in memory and when a warning event or worse occurs, dumps the log for that specific thread. The current implementation won't log if errors appear in the main thread (the manager). Almost all problems anyway occur in the match threads. The log is cleared between games.

Just an experiment right now