### PR TITLE
Use "fischerandom" for PGN output in cutechess mode

### DIFF
--- a/app/src/game/pgn/pgn_builder.cpp
+++ b/app/src/game/pgn/pgn_builder.cpp
@@ -39,7 +39,11 @@ PgnBuilder::PgnBuilder(const config::Pgn &pgn_config, const MatchData &match, st
     }
 
     if (is_frc_variant) {
+#ifdef USE_CUTE
+        addHeader("Variant", "fischerandom");
+#else
         addHeader("Variant", "Chess960");
+#endif
     }
 
     if (!pgn_config_.min) {


### PR DESCRIPTION
Not sure if this is the best way to implement this (and if you want to extend the cutechess compatibility behaviour to the PGN output).