### PR TITLE
refactor: free up engine cache with restart option

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -109,7 +109,7 @@ endif
 endif
 
 ifeq ($(build), debug)
-	CXXFLAGS := -O0 -std=c++17 -Wall -Wextra -pedantic -Wuninitialized -g3
+	CXXFLAGS := -O0 -std=c++17 -Wall -Wextra -pedantic -Wuninitialized -g3 -D_GLIBCXX_ASSERTIONS
 endif
 
 ifeq ($(build), release)

--- a/app/src/core/memory/scope_guard.hpp
+++ b/app/src/core/memory/scope_guard.hpp
@@ -21,21 +21,29 @@ class ScopeEntry {
 template <typename T>
 class ScopeGuard {
    public:
-    explicit ScopeGuard(T &entry) : entry_(entry) {
+    explicit ScopeGuard(T *entry) : entry_(entry) {
         static_assert(std::is_base_of<ScopeEntry, T>::value,
                       "type parameter of this class must derive from ScopeEntry");
     }
 
-    ~ScopeGuard() { entry_.release(); }
+    explicit ScopeGuard(T &entry) : entry_(&entry) {
+        static_assert(std::is_base_of<ScopeEntry, T>::value,
+                      "type parameter of this class must derive from ScopeEntry");
+    }
+
+    ~ScopeGuard() {
+        if (entry_ == nullptr) return;
+        entry_->release();
+    }
 
     ScopeGuard(const ScopeGuard &)            = delete;
     ScopeGuard &operator=(const ScopeGuard &) = delete;
 
-    [[nodiscard]] auto &get() noexcept { return entry_; }
-    [[nodiscard]] auto &get() const noexcept { return entry_; }
+    [[nodiscard]] auto &get() noexcept { return *entry_; }
+    [[nodiscard]] auto &get() const noexcept { return *entry_; }
 
    private:
-    T &entry_;
+    T *entry_;
 };
 
 }  // namespace fastchess::util

--- a/app/src/matchmaking/tournament/base/tournament.cpp
+++ b/app/src/matchmaking/tournament/base/tournament.cpp
@@ -216,7 +216,6 @@ int BaseTournament::getMaxAffinity(const std::vector<EngineConfiguration> &confi
 }
 
 void BaseTournament::restartEngine(std::unique_ptr<engine::UciEngine> &engine) {
-    std::cout << "Restarting engine " << engine->getConfig().name << std::endl;
     LOG_TRACE_THREAD("Restarting engine {}", engine->getConfig().name);
     auto config = engine->getConfig();
     auto rl     = engine->isRealtimeLogging();


### PR DESCRIPTION
tournament with 5 engines and 10 concurrency previously consuming 14.2G + 2.76G (swap) memory & potentially more.. with engines using restart option only 9.2G