### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ MANDIR = $(PREFIX)/share/man/man1
 MANPAGE_SOURCE = man.md  # Path to the markdown file for the man page
 MANPAGE_OUTPUT = fastchess.1
 
-.PHONY: all tests install manpage install-manpage update-man clean format update-fmt help coverage
-
 ifeq ($(shell uname), Linux)
 	LOWDOWN_INSTALLED := $(shell command -v lowdown >/dev/null 2>&1 && echo yes || echo no)
 endif
@@ -84,3 +82,4 @@ clean: ## Clean up
 help: ## Print this help
 	@egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: all tests install manpage install-manpage update-man clean format update-fmt help coverage

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ install: ## Install the binary and man page
 	@install -d $(BINDIR)
 	@install fastchess $(BINDIR)
 	@if [ "$(shell uname)" = "Linux" ] && [ "$(LOWDOWN_INSTALLED)" = "no" ]; then \
-		echo "\033[33mWarning: 'lowdown' is not installed. Man page will not be generated.\033[0m"; \
+		printf "\033[33mWarning: 'lowdown' is not installed. Man page will not be generated.\033[0m\n"; \
 	else \
 		make install-manpage --no-print-directory ; \
 	fi


### PR DESCRIPTION
The first error is because the .PHONY line is right before the ifeq. On my system (GNU Make 4.4.1) this means that the ifeq is never executed and there is thus no check for the existence of lowdown. I get the following error when installing:
```
Installing fastchess binary to: /usr/local/bin
/bin/sh: line 1: lowdown: command not found
make[1]: *** [Makefile:45: manpage] Error 127
make: *** [Makefile:37: install] Error 2
```
To fix this, we can move the .PHONY line to e.g. the last line.

The second problem comes with echo. Bash' built-in echo, and GNU echo, both require the -e flag to escape expand. However other echo implementations may be confused by the -e flag. The portable way is to use printf instead.