### PR TITLE
Fix illegal pv warning

### DIFF
--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -524,15 +524,15 @@ void Match::verifyPvLines(const Player& us) {
             if (gameover || illegal_move) {
                 std::string warning;
                 if (illegal_move) {
-                    warning = "Warning: Illegal PV move - move {} from {}";
+                    warning = "Warning; Illegal PV move - move {} from {}";
                 } else if (gameoverResult.first == GameResultReason::THREEFOLD_REPETITION) {
-                    warning = "Warning: PV continues after threefold repetition - move {} from {}";
+                    warning = "Warning; PV continues after threefold repetition - move {} from {}";
                 } else if (gameoverResult.first == GameResultReason::FIFTY_MOVE_RULE) {
-                    warning = "Warning: PV continues after fifty-move rule - move {} from {}";
+                    warning = "Warning; PV continues after fifty-move rule - move {} from {}";
                 } else if (gameoverResult.first == GameResultReason::CHECKMATE) {
-                    warning = "Warning: PV continues after checkmate - move {} from {}";
+                    warning = "Warning; PV continues after checkmate - move {} from {}";
                 } else if (gameoverResult.first == GameResultReason::STALEMATE) {
-                    warning = "Warning: PV continues after stalemate - move {} from {}";
+                    warning = "Warning; PV continues after stalemate - move {} from {}";
                 }
 
                 assert(!warning.empty());

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -514,7 +514,7 @@ void Match::verifyPvLines(const Player& us) {
             const auto gameoverResult = isGameOverSimple(board);
             const auto gameover       = gameoverResult.second != GameResult::NONE;
 
-            if (!gameover) {
+            if (gameoverResult.first != GameResultReason::CHECKMATE && gameoverResult.first != GameResultReason::STALEMATE) {
                 movegen::legalmoves(moves, board);
             }
 
@@ -523,7 +523,9 @@ void Match::verifyPvLines(const Player& us) {
 
             if (gameover || illegal_move) {
                 std::string warning;
-                if (gameoverResult.first == GameResultReason::THREEFOLD_REPETITION) {
+                if (illegal_move) {
+                    warning = "Warning: Illegal PV move - move {} from {}";
+                } else if (gameoverResult.first == GameResultReason::THREEFOLD_REPETITION) {
                     warning = "Warning: PV continues after threefold repetition - move {} from {}";
                 } else if (gameoverResult.first == GameResultReason::FIFTY_MOVE_RULE) {
                     warning = "Warning: PV continues after fifty-move rule - move {} from {}";
@@ -531,8 +533,6 @@ void Match::verifyPvLines(const Player& us) {
                     warning = "Warning: PV continues after checkmate - move {} from {}";
                 } else if (gameoverResult.first == GameResultReason::STALEMATE) {
                     warning = "Warning: PV continues after stalemate - move {} from {}";
-                } else if (illegal_move) {
-                    warning = "Warning: PV continues after illegal move - move {} from {}";
                 }
 
                 assert(!warning.empty());

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -509,7 +509,8 @@ void Match::verifyPvLines(const Player& us) {
         while (it_start != it_end) {
             moves.clear();
 
-            const auto gameover = isGameOverSimple(board).second != GameResult::NONE;
+            const auto gameoverPair = isGameOverSimple(board);
+            const auto gameover = gameoverPair.second != GameResult::NONE && (gameoverPair.first == GameResultReason::CHECKMATE || gameoverPair.first == GameResultReason::STALEMATE);
 
             if (!gameover) {
                 movegen::legalmoves(moves, board);


### PR DESCRIPTION
FIDE rules state that a player _may_ claim a draw for both threefold repetitions and the 50 move rule, but it is not mandatory. Outputting pv moves past a threefold repetition and 50 quiet moves is thus not illegal, and fastchess should accordingly not warn if this happens.