### PR TITLE
sprt: terminate LLR calculation after 10 iterations

### DIFF
--- a/app/src/matchmaking/sprt/sprt.cpp
+++ b/app/src/matchmaking/sprt/sprt.cpp
@@ -257,7 +257,7 @@ double SPRT::getLLR_normalized(double total, std::array<double, N> scores, std::
         std::array<double, N> p;
         std::fill(p.begin(), p.end(), 1.0 / N);
 
-        while (true) {
+        for (int iterations = 0; iterations < 10; iterations++) {
             // Calculate phi.
             auto [mu, var] = mean_and_variance(scores, p);
             std::array<double, N> phi;


### PR DESCRIPTION
Fishtest terminates LLR calcuations after 10 iterations if it was not able to converge with the desired error. See: <https://github.com/official-stockfish/fishtest/blob/4f41ae1903df5e1de1fdb00f54c7c1410ac04dc9/server/fishtest/stats/LLRcalc.py#L86>

Do the same to avoid issue #877.