### PR TITLE
refactor!: remove extra dash for force-concurrency option

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -724,7 +724,7 @@ OptionsParser::OptionsParser(const cli::Args &args) {
     addOption("output", parseOutput);
     addOption("concurrency", parseConcurrency);
     addOption("crc32", parseCrc);
-    addOption("-force-concurrency", parseForceConcurrency);
+    addOption("force-concurrency", parseForceConcurrency);
     addOption("event", parseEvent);
     addOption("site", parseSite);
     addOption("games", parseGames);

--- a/app/src/cli/sanitize.cpp
+++ b/app/src/cli/sanitize.cpp
@@ -35,7 +35,7 @@ void sanitize(config::Tournament& config) {
     }
 
     if (config.concurrency > static_cast<int>(std::thread::hardware_concurrency()) && !config.force_concurrency) {
-        throw std::runtime_error("Error: Concurrency exceeds number of CPUs. Use --force-concurrency to override.");
+        throw std::runtime_error("Error: Concurrency exceeds number of CPUs. Use -force-concurrency to override.");
     }
 
 #ifdef _WIN64

--- a/app/tests/cli_test.cpp
+++ b/app/tests/cli_test.cpp
@@ -48,7 +48,7 @@ TEST_SUITE("Option Parsing Tests") {
         };
 
         CHECK_THROWS_WITH_AS(cli::OptionsParser{args},
-                             "Error: Concurrency exceeds number of CPUs. Use --force-concurrency to override.",
+                             "Error: Concurrency exceeds number of CPUs. Use -force-concurrency to override.",
                              std::runtime_error);
     }
 

--- a/man.md
+++ b/man.md
@@ -41,7 +41,7 @@ The following options are available:
 - -crc32 pgn=true
     Calculate the CRC32 checksum for the PGN file.
 
-- --force-concurrency  
+- -force-concurrency
     Ignore the hardware concurrency limit and force the specified concurrency.
 
 - -rounds N  


### PR DESCRIPTION
not consistent with the other options