### PR TITLE
sprt: alternative initial p value in normalized LLR calculation

### DIFF
--- a/app/src/matchmaking/sprt/sprt.cpp
+++ b/app/src/matchmaking/sprt/sprt.cpp
@@ -289,7 +289,10 @@ double SPRT::getLLR_normalized(double total, std::array<double, N> scores, std::
         }
 
         for (int iterations = 0; iterations < 10; iterations++) {
-            auto [phi, u, v] = calc_phi();
+            std::array<double, N> phi;
+            double u;
+            double v;
+            std::tie(phi, u, v) = calc_phi();
 
             double min_theta = -1.0 / v;
             double max_theta = -1.0 / u;


### PR DESCRIPTION
Fixes #879.

@vdbergh: Are there any good alternatives here? As one possible alternative to this, what are your thoughts on using the MLE of the distribution given the expectation as an initial value for determining the MLE of the distribution for the t-value?