### PR TITLE
fix: wait 10s before sending sigkill to engine after quit

### DIFF
--- a/app/src/engine/process/iprocess.hpp
+++ b/app/src/engine/process/iprocess.hpp
@@ -49,6 +49,8 @@ class IProcess {
     // Write input to the engine's stdin
     virtual Status writeInput(const std::string &input) noexcept = 0;
 
+    constexpr static std::chrono::seconds kill_timeout{60};
+
    protected:
     [[nodiscard]] std::string getPath(const std::string &dir, const std::string &cmd) const {
         std::string path = (dir == "." ? "" : dir) + cmd;

--- a/app/src/engine/process/process_posix.hpp
+++ b/app/src/engine/process/process_posix.hpp
@@ -292,7 +292,7 @@ class Process : public IProcess {
 
             pid_t pid = 0;
 
-            // give the process 10s to die gracefully
+            // give the process time to die gracefully
             while (std::chrono::steady_clock::now() - start_time < IProcess::kill_timeout) {
                 pid = waitpid(process_pid_, &status, WNOHANG);
 

--- a/app/src/engine/process/process_posix.hpp
+++ b/app/src/engine/process/process_posix.hpp
@@ -289,12 +289,11 @@ class Process : public IProcess {
 
         if (!exit_code_.has_value()) {
             const auto start_time = std::chrono::steady_clock::now();
-            const auto timeout    = std::chrono::seconds(10);
 
             pid_t pid = 0;
 
             // give the process 10s to die gracefully
-            while (std::chrono::steady_clock::now() - start_time < timeout) {
+            while (std::chrono::steady_clock::now() - start_time < IProcess::kill_timeout) {
                 pid = waitpid(process_pid_, &status, WNOHANG);
 
                 if (pid > 0) {

--- a/app/src/engine/process/process_win.hpp
+++ b/app/src/engine/process/process_win.hpp
@@ -129,11 +129,16 @@ class Process : public IProcess {
         process_list.remove_if([this](const auto &pi) { return pi.identifier == pi_.hProcess; });
 
         DWORD exitCode = 0;
-        GetExitCodeProcess(pi_.hProcess, &exitCode);
 
-        if (exitCode == STILL_ACTIVE) {
-            TerminateProcess(pi_.hProcess, 0);
+        // Wait for the process to terminate, with a 10-second timeout
+        DWORD waitResult = WaitForSingleObject(pi_.hProcess, 10000);
+
+        if (waitResult == WAIT_TIMEOUT) {
+            TerminateProcess(pi_.hProcess, 1);
+            WaitForSingleObject(pi_.hProcess, 1000);
         }
+
+        GetExitCodeProcess(pi_.hProcess, &exitCode);
 
         is_initialized_ = false;
     }

--- a/app/src/engine/process/process_win.hpp
+++ b/app/src/engine/process/process_win.hpp
@@ -130,9 +130,8 @@ class Process : public IProcess {
 
         DWORD exitCode        = 0;
         const auto start_time = std::chrono::steady_clock::now();
-        const auto timeout    = std::chrono::seconds(10);
 
-        while (std::chrono::steady_clock::now() - start_time < timeout) {
+        while (std::chrono::steady_clock::now() - start_time < IProcess::kill_timeout) {
             GetExitCodeProcess(pi_.hProcess, &exitCode);
 
             if (exitCode != STILL_ACTIVE) {

--- a/app/src/engine/process/process_win.hpp
+++ b/app/src/engine/process/process_win.hpp
@@ -149,7 +149,7 @@ class Process : public IProcess {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             GetExitCodeProcess(pi_.hProcess, &exitCode);
         } else {
-            LOG_TRACE_THREAD("Process with pid: {} terminated with status: {}", process_pid_, exitCode);
+            LOG_TRACE_THREAD("Process with pid: {} terminated with status: {}", pi_.hProcess, exitCode);
         }
 
         is_initialized_ = false;

--- a/app/src/engine/process/process_win.hpp
+++ b/app/src/engine/process/process_win.hpp
@@ -131,6 +131,7 @@ class Process : public IProcess {
         DWORD exitCode        = 0;
         const auto start_time = std::chrono::steady_clock::now();
 
+        // give the process time to die gracefully
         while (std::chrono::steady_clock::now() - start_time < IProcess::kill_timeout) {
             GetExitCodeProcess(pi_.hProcess, &exitCode);
 


### PR DESCRIPTION
previously engines received a sigkill immediately after a quit command, if this input wasn't transfered fast enough to the engine then the engine was immediately sigkilled which might prevent resource freeing.. instead wait 10s before an engine receives a sigkill after a quit