### PR TITLE
refactor: stop tournament when match creation threw exception

### DIFF
--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -308,6 +308,8 @@ tl::expected<bool, std::string> UciEngine::start() {
         return tl::make_unexpected("Couldn't start engine process");
     }
 
+    initialized_ = true;
+
     // Wait for the engine to start
     if (!uci()) {
         return tl::make_unexpected("Couldn't write uci to engine");
@@ -316,8 +318,6 @@ tl::expected<bool, std::string> UciEngine::start() {
     if (!uciok(startup_time_)) {
         return tl::make_unexpected("Engine didn't respond to uciok after startup");
     }
-
-    initialized_ = true;
 
     return true;
 }

--- a/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
+++ b/app/src/matchmaking/tournament/roundrobin/roundrobin.cpp
@@ -68,6 +68,8 @@ void RoundRobin::startNext() {
             this->createMatch(match.value());
         } catch (const std::exception& e) {
             Logger::print<Logger::Level::ERR>("Error while creating match: {}", e.what());
+            atomic::stop                 = true;
+            atomic::abnormal_termination = true;
         }
     });
 }


### PR DESCRIPTION
also move initialized higher so that engines dont wait for the kill timeout and instead first try to use "quit"