### PR TITLE
fix: make sure the engine executable exists

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -155,9 +155,6 @@ bool isEngineSettableOption(std::string_view stringFormat) { return str_utils::s
 void parseEngineKeyValues(EngineConfiguration &engineConfig, const std::string &key, const std::string &value) {
     if (key == "cmd") {
         engineConfig.cmd = value;
-        if (!(std::filesystem::exists(engineConfig.cmd) && std::filesystem::is_regular_file(engineConfig.cmd))) {
-            throw std::runtime_error("Engine binary does not exist: " + engineConfig.cmd);
-        }
     } else if (key == "name")
         engineConfig.name = value;
     else if (key == "tc")

--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -155,6 +155,9 @@ bool isEngineSettableOption(std::string_view stringFormat) { return str_utils::s
 void parseEngineKeyValues(EngineConfiguration &engineConfig, const std::string &key, const std::string &value) {
     if (key == "cmd") {
         engineConfig.cmd = value;
+        if (!(std::filesystem::exists(engineConfig.cmd) && std::filesystem::is_regular_file(engineConfig.cmd))) {
+            throw std::runtime_error("Engine binary does not exist: " + engineConfig.cmd);
+        }
     } else if (key == "name")
         engineConfig.name = value;
     else if (key == "tc")

--- a/app/src/cli/sanitize.cpp
+++ b/app/src/cli/sanitize.cpp
@@ -133,7 +133,7 @@ void sanitize(std::vector<EngineConfiguration>& configs) {
         }
 
         if (!configs[i].dir.empty() || enginePath.is_absolute()) {
-            if (!(std::filesystem::exists(enginePath) && std::filesystem::is_regular_file(enginePath))) {
+            if (!std::filesystem::is_regular_file(enginePath)) {
                 throw std::runtime_error("Engine binary does not exist: " + enginePath.string());
             }
         }

--- a/app/src/cli/sanitize.cpp
+++ b/app/src/cli/sanitize.cpp
@@ -125,6 +125,19 @@ void sanitize(std::vector<EngineConfiguration>& configs) {
                 throw std::runtime_error("Error: Engine with the same name are not allowed!: " + configs[i].name);
             }
         }
+
+#ifndef NO_STD_FILESYSTEM
+        std::filesystem::path enginePath = configs[i].cmd;
+        if (!configs[i].dir.empty()) {
+            enginePath = (std::filesystem::path(configs[i].dir) / configs[i].cmd);
+        }
+
+        if (!configs[i].dir.empty() || enginePath.is_absolute()) {
+            if (!(std::filesystem::exists(enginePath) && std::filesystem::is_regular_file(enginePath))) {
+                throw std::runtime_error("Engine binary does not exist: " + enginePath.string());
+            }
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
Exit right away if the engine isn’t found.
This makes the error message clearer by saying the executable doesn’t exist, rather than showing the previous generic one: "Fatal; <engine_name> engine startup failure: Couldn't start engine process."