### PR TITLE
refactor: replace raw new[] with std::make_unique in getCpuInfo

### DIFF
--- a/app/src/affinity/cpuinfo/cpuinfo_win.hpp
+++ b/app/src/affinity/cpuinfo/cpuinfo_win.hpp
@@ -38,8 +38,8 @@ inline CpuInfo getCpuInfo() noexcept(false) {
 
     GetLogicalProcessorInformationEx(RelationProcessorPackage, nullptr, &byte_length);
 
-    std::unique_ptr<char[]> buffer(new char[byte_length]);
-    auto ptr = PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX(buffer.get());
+    auto buffer = std::make_unique<char[]>(byte_length);
+    auto ptr    = PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX(buffer.get());
 
     if (!GetLogicalProcessorInformationEx(RelationProcessorPackage, ptr, &byte_length)) {
         std::cerr << "GetLogicalProcessorInformationEx failed." << std::endl;


### PR DESCRIPTION
According to Scott Meyers Effective Modern C++
**_Item 21: Prefer std::make_unique and std::make_shared to direct use of new._**

This is my first contribution, I have made sure the unit tests have passed.