### PR TITLE
Set process affinity upon match start.

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -114,6 +114,9 @@ endif
 
 ifeq ($(build), debug)
 	CXXFLAGS := -O0 -std=c++17 -Wall -Wextra -pedantic -Wuninitialized -g3 -D_GLIBCXX_ASSERTIONS
+	ifeq ($(uname_S), Windows)
+		LDFLAGS += -static
+	endif
 endif
 
 ifeq ($(build), release)

--- a/app/src/affinity/affinity.hpp
+++ b/app/src/affinity/affinity.hpp
@@ -20,35 +20,82 @@ namespace affinity {
 
 #ifdef _WIN64
 
-inline bool setAffinity(const std::vector<int>& cpus, HANDLE process_handle) noexcept {
+namespace detail {
+
+template <typename F>
+[[nodiscard]] F getWindowsApi(const char* func_name) {
+    const HMODULE hModule = GetModuleHandle(TEXT("kernel32.dll"));
+    if (!hModule) {
+        return nullptr;
+    }
+
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wcast-function-type"
+    const auto pFunc = reinterpret_cast<F>(GetProcAddress(hModule, func_name));
+#    pragma GCC diagnostic pop
+
+    return pFunc;
+}
+
+[[nodiscard]] inline std::vector<GROUP_AFFINITY> getGroupAffinities(const std::vector<int>& cpus) {
+    // Create an array of GROUP_AFFINITY structures
+    std::vector<GROUP_AFFINITY> groupAffinities(cpus.size());
+
+    for (size_t i = 0; i < cpus.size(); ++i) {
+        GROUP_AFFINITY& ga = groupAffinities[i];
+        ZeroMemory(&ga, sizeof(GROUP_AFFINITY));
+        ga.Mask  = 1ull << (cpus[i] % 64);           // Assuming cpus[i] is the logical processor number
+        ga.Group = static_cast<WORD>(cpus[i] / 64);  // Assuming each group has 64 processors
+    }
+
+    return groupAffinities;
+}
+
+}  // namespace detail
+
+inline bool setThreadAffinity(const std::vector<int>& cpus, HANDLE thread_handle) noexcept {
+    LOG_TRACE("Setting affinity mask for thread handle: {}", thread_handle);
+    using SetThreadSelectedCpuSetMasksFunc = BOOL(WINAPI*)(HANDLE, PGROUP_AFFINITY, USHORT);
+
+    // Check if SetThreadSelectedCpuSetMasks is available (Windows 11+)
+    const auto pSetThreadSelectedCpuSetMasks =
+        detail::getWindowsApi<SetThreadSelectedCpuSetMasksFunc>("SetThreadSelectedCpuSetMasks");
+    if (pSetThreadSelectedCpuSetMasks) {
+        std::vector<GROUP_AFFINITY> groupAffinities = detail::getGroupAffinities(cpus);
+
+        // Set the CPU set masks for the thread
+        return pSetThreadSelectedCpuSetMasks(thread_handle, groupAffinities.data(),
+                                             static_cast<USHORT>(groupAffinities.size())) != 0;
+    }
+
+    // Fallback to SetThreadAffinityMask for older Windows versions (limited to 64 CPUs)
+    DWORD_PTR affinity_mask = 0;
+    for (const auto& cpu : cpus) {
+        if (cpu > 63) {
+            Logger::print<Logger::Level::ERR>(
+                "Setting thread affinity for more than 64 logical CPUs is not supported: requires at least Windows 11 "
+                "or Windows Server 2022.");
+            return false;
+        }
+        affinity_mask |= (1ull << cpu);
+    }
+
+    return SetThreadAffinityMask(thread_handle, affinity_mask) != 0;
+}
+
+inline bool setProcessAffinity(const std::vector<int>& cpus, HANDLE process_handle) noexcept {
     LOG_TRACE("Setting affinity mask for process handle: {}", process_handle);
     using SetProcessDefaultCpuSetMasksFunc = BOOL(WINAPI*)(HANDLE, PGROUP_AFFINITY, USHORT);
 
     // Check if SetProcessDefaultCpuSetMasks is available
-    const HMODULE hModule = GetModuleHandle(TEXT("kernel32.dll"));
-    if (hModule) {
-        // casting the function pointer to the target type is required by the API, so temporarily suppress the warning.
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wcast-function-type"
-        const auto pSetProcessDefaultCpuSetMasks =
-            reinterpret_cast<SetProcessDefaultCpuSetMasksFunc>(GetProcAddress(hModule, "SetProcessDefaultCpuSetMasks"));
-#    pragma GCC diagnostic pop
+    const auto pSetProcessDefaultCpuSetMasks =
+        detail::getWindowsApi<SetProcessDefaultCpuSetMasksFunc>("SetProcessDefaultCpuSetMasks");
+    if (pSetProcessDefaultCpuSetMasks) {
+        std::vector<GROUP_AFFINITY> groupAffinities = detail::getGroupAffinities(cpus);
 
-        if (pSetProcessDefaultCpuSetMasks) {
-            // Create an array of GROUP_AFFINITY structures
-            std::vector<GROUP_AFFINITY> groupAffinities(cpus.size());
-
-            for (size_t i = 0; i < cpus.size(); ++i) {
-                GROUP_AFFINITY& ga = groupAffinities[i];
-                ZeroMemory(&ga, sizeof(GROUP_AFFINITY));
-                ga.Mask  = 1ull << (cpus[i] % 64);           // Assuming cpus[i] is the logical processor number
-                ga.Group = static_cast<WORD>(cpus[i] / 64);  // Assuming each group has 64 processors
-            }
-
-            // Set the CPU set masks for the process
-            return pSetProcessDefaultCpuSetMasks(process_handle, groupAffinities.data(),
-                                                 static_cast<USHORT>(groupAffinities.size())) == TRUE;
-        }
+        // Set the CPU set masks for the process
+        return pSetProcessDefaultCpuSetMasks(process_handle, groupAffinities.data(),
+                                             static_cast<USHORT>(groupAffinities.size())) == TRUE;
     }
 
     // Fallback to SetProcessAffinityMask for older Windows versions
@@ -69,7 +116,12 @@ inline bool setAffinity(const std::vector<int>& cpus, HANDLE process_handle) noe
 
 #elif defined(__APPLE__)
 
-inline bool setAffinity(const std::vector<int>&, pid_t) noexcept {
+inline bool setThreadAffinity(const std::vector<int>&, pid_t) noexcept {
+    // Not implemented.
+    return false;
+}
+
+inline bool setProcessAffinity(const std::vector<int>&, pid_t) noexcept {
     // mach_port_t tid = pthread_mach_thread_np(pthread_self());
     // struct thread_affinity_policy policy;
     // policy.affinity_tag = affinity_mask;
@@ -83,8 +135,8 @@ inline bool setAffinity(const std::vector<int>&, pid_t) noexcept {
 
 #else
 
-inline bool setAffinity(const std::vector<int>& cpus, pid_t process_pid) noexcept {
-    LOG_TRACE("Setting affinity mask for process pid: {}", process_pid);
+inline bool setThreadAffinity(const std::vector<int>& cpus, pid_t thread_pid) noexcept {
+    LOG_TRACE("Setting affinity mask for thread pid: {}", thread_pid);
 
     cpu_set_t mask;
     CPU_ZERO(&mask);
@@ -93,9 +145,13 @@ inline bool setAffinity(const std::vector<int>& cpus, pid_t process_pid) noexcep
         CPU_SET(cpu, &mask);
     }
 
-    return sched_setaffinity(process_pid, sizeof(cpu_set_t), &mask) == 0;
+    return sched_setaffinity(thread_pid, sizeof(cpu_set_t), &mask) == 0;
 }
 
+inline bool setProcessAffinity(const std::vector<int>& cpus, pid_t process_pid) noexcept {
+    // Set the affinity for the process by setting the affinity for its main thread.
+    return setThreadAffinity(cpus, process_pid);
+}
 #endif
 
 #ifdef _WIN64

--- a/app/src/affinity/affinity.hpp
+++ b/app/src/affinity/affinity.hpp
@@ -53,7 +53,7 @@ template <typename F>
 
 }  // namespace detail
 
-inline bool setThreadAffinity(const std::vector<int>& cpus, HANDLE thread_handle) noexcept {
+[[nodiscard]] inline bool setThreadAffinity(const std::vector<int>& cpus, HANDLE thread_handle) noexcept {
     LOG_TRACE("Setting affinity mask for thread handle: {}", thread_handle);
     using SetThreadSelectedCpuSetMasksFunc = BOOL(WINAPI*)(HANDLE, PGROUP_AFFINITY, USHORT);
 
@@ -83,7 +83,7 @@ inline bool setThreadAffinity(const std::vector<int>& cpus, HANDLE thread_handle
     return SetThreadAffinityMask(thread_handle, affinity_mask) != 0;
 }
 
-inline bool setProcessAffinity(const std::vector<int>& cpus, HANDLE process_handle) noexcept {
+[[nodiscard]] inline bool setProcessAffinity(const std::vector<int>& cpus, HANDLE process_handle) noexcept {
     LOG_TRACE("Setting affinity mask for process handle: {}", process_handle);
     using SetProcessDefaultCpuSetMasksFunc = BOOL(WINAPI*)(HANDLE, PGROUP_AFFINITY, USHORT);
 
@@ -116,12 +116,12 @@ inline bool setProcessAffinity(const std::vector<int>& cpus, HANDLE process_hand
 
 #elif defined(__APPLE__)
 
-inline bool setThreadAffinity(const std::vector<int>&, pid_t) noexcept {
+[[nodiscard]] inline bool setThreadAffinity(const std::vector<int>&, pid_t) noexcept {
     // Not implemented.
     return false;
 }
 
-inline bool setProcessAffinity(const std::vector<int>&, pid_t) noexcept {
+[[nodiscard]] inline bool setProcessAffinity(const std::vector<int>&, pid_t) noexcept {
     // mach_port_t tid = pthread_mach_thread_np(pthread_self());
     // struct thread_affinity_policy policy;
     // policy.affinity_tag = affinity_mask;
@@ -135,7 +135,7 @@ inline bool setProcessAffinity(const std::vector<int>&, pid_t) noexcept {
 
 #else
 
-inline bool setThreadAffinity(const std::vector<int>& cpus, pid_t thread_pid) noexcept {
+[[nodiscard]] inline bool setThreadAffinity(const std::vector<int>& cpus, pid_t thread_pid) noexcept {
     LOG_TRACE("Setting affinity mask for thread pid: {}", thread_pid);
 
     cpu_set_t mask;
@@ -148,22 +148,22 @@ inline bool setThreadAffinity(const std::vector<int>& cpus, pid_t thread_pid) no
     return sched_setaffinity(thread_pid, sizeof(cpu_set_t), &mask) == 0;
 }
 
-inline bool setProcessAffinity(const std::vector<int>& cpus, pid_t process_pid) noexcept {
+[[nodiscard]] inline bool setProcessAffinity(const std::vector<int>& cpus, pid_t process_pid) noexcept {
     // Set the affinity for the process by setting the affinity for its main thread.
     return setThreadAffinity(cpus, process_pid);
 }
 #endif
 
 #ifdef _WIN64
-inline HANDLE getProcessHandle() noexcept { return GetCurrentProcess(); }
+[[nodiscard]] inline HANDLE getProcessHandle() noexcept { return GetCurrentProcess(); }
 #else
-inline pid_t getProcessHandle() noexcept { return getpid(); }
+[[nodiscard]] inline pid_t getProcessHandle() noexcept { return getpid(); }
 #endif
 
 #ifdef _WIN64
-inline HANDLE getThreadHandle() noexcept { return GetCurrentThread(); }
+[[nodiscard]] inline HANDLE getThreadHandle() noexcept { return GetCurrentThread(); }
 #else
-inline pid_t getThreadHandle() noexcept {
+[[nodiscard]] inline pid_t getThreadHandle() noexcept {
 #    ifdef __APPLE__
     // dummy
     return 0;

--- a/app/src/engine/compliance.hpp
+++ b/app/src/engine/compliance.hpp
@@ -61,7 +61,7 @@ inline bool compliant(int argc, char const *argv[]) {
     UciEngine uci_engine(config, false);
 
     std::vector<std::pair<std::string, std::function<bool()>>> steps = {
-        {"Start the engine", [&uci_engine] { return uci_engine.start().has_value(); }},
+        {"Start the engine", [&uci_engine] { return uci_engine.start(/*cpus*/ std::nullopt).has_value(); }},
         {"Check if engine is ready", [&uci_engine] { return uci_engine.isready() == process::Status::OK; }},
         {"Check id name", [&uci_engine] { return uci_engine.idName().has_value(); }},
         {"Check id author", [&uci_engine] { return uci_engine.idAuthor().has_value(); }},

--- a/app/src/engine/process/process_posix.hpp
+++ b/app/src/engine/process/process_posix.hpp
@@ -272,7 +272,7 @@ class Process : public IProcess {
         assert(false && "This function should not be called on Apple devices");
 #    endif
 
-        return affinity::setAffinity(cpus, process_pid_);
+        return affinity::setProcessAffinity(cpus, process_pid_);
     }
 
     void terminate() {

--- a/app/src/engine/process/process_win.hpp
+++ b/app/src/engine/process/process_win.hpp
@@ -116,7 +116,7 @@ class Process : public IProcess {
 
     bool setAffinity(const std::vector<int> &cpus) noexcept override {
         assert(is_initialized_);
-        return affinity::setAffinity(cpus, pi_.hProcess);
+        return affinity::setProcessAffinity(cpus, pi_.hProcess);
     }
 
     void terminate() {

--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -295,7 +295,7 @@ void UciEngine::sendSetoption(const std::string &name, const std::string &value)
     option.value()->setValue(value);
 }
 
-tl::expected<bool, std::string> UciEngine::start() {
+tl::expected<bool, std::string> UciEngine::start(const std::optional<std::vector<int>> &cpus) {
     if (initialized_) return true;
 
     AcquireSemaphore semaphore_acquire(semaphore);
@@ -306,6 +306,10 @@ tl::expected<bool, std::string> UciEngine::start() {
     // Creates the engine process and sets the pipes
     if (process_.init(config_.dir, path, config_.args, config_.name) != process::Status::OK) {
         return tl::make_unexpected("Couldn't start engine process");
+    }
+
+    if (cpus) {
+        setCpus(*cpus);
     }
 
     initialized_ = true;

--- a/app/src/engine/uci_engine.hpp
+++ b/app/src/engine/uci_engine.hpp
@@ -34,7 +34,7 @@ class UciEngine {
 
     // Starts the engine, does nothing after the first call.
     // Returns false if the engine is not alive.
-    [[nodiscard]] tl::expected<bool, std::string> start();
+    [[nodiscard]] tl::expected<bool, std::string> start(const std::optional<std::vector<int>> &cpus);
 
     // Restarts the engine, if necessary and reapplies the options.
     bool refreshUci();

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -164,14 +164,14 @@ void Match::addMoveData(const Player& player, int64_t measured_time_ms, int64_t 
     uci_moves_.push_back(move);
 }
 
-void Match::start(engine::UciEngine& white, engine::UciEngine& black) {
+void Match::start(engine::UciEngine& white, engine::UciEngine& black, std::optional<std::vector<int>>& cpus) {
     std::transform(data_.moves.begin(), data_.moves.end(), std::back_inserter(uci_moves_),
                    [](const MoveData& data) { return data.move; });
 
     Player white_player = Player(white);
     Player black_player = Player(black);
 
-    if (auto ret = white_player.engine.start(); !ret) {
+    if (auto ret = white_player.engine.start(cpus); !ret) {
         if (atomic::stop.load()) return;
 
         atomic::stop                 = true;
@@ -183,7 +183,7 @@ void Match::start(engine::UciEngine& white, engine::UciEngine& black) {
         return;
     }
 
-    if (auto ret = black_player.engine.start(); !ret) {
+    if (auto ret = black_player.engine.start(cpus); !ret) {
         if (atomic::stop.load()) return;
         atomic::stop                 = true;
         atomic::abnormal_termination = true;

--- a/app/src/matchmaking/match/match.hpp
+++ b/app/src/matchmaking/match/match.hpp
@@ -135,7 +135,7 @@ class Match {
     Match(const book::Opening& opening);
 
     // starts the match
-    void start(engine::UciEngine& white, engine::UciEngine& black);
+    void start(engine::UciEngine& white, engine::UciEngine& black, std::optional<std::vector<int>>& cpus);
 
     // returns the match data, only valid after the match has finished
     [[nodiscard]] const MatchData& get() const { return data_; }

--- a/app/tests/uci_engine_test.cpp
+++ b/app/tests/uci_engine_test.cpp
@@ -34,7 +34,7 @@ TEST_SUITE("Uci Engine Communication Tests") {
 
         engine::UciEngine uci_engine = engine::UciEngine(config, false);
 
-        CHECK(uci_engine.start());
+        CHECK(uci_engine.start(/*cpus*/ std::nullopt));
 
         for (const auto& line : uci_engine.output()) {
             std::cout << line.line << std::endl;
@@ -63,7 +63,7 @@ TEST_SUITE("Uci Engine Communication Tests") {
 
         engine::UciEngine uci_engine = engine::UciEngine(config, false);
 
-        CHECK(uci_engine.start());
+        CHECK(uci_engine.start(/*cpus*/ std::nullopt));
 
         for (const auto& line : uci_engine.output()) {
             std::cout << line.line << std::endl;
@@ -86,7 +86,7 @@ TEST_SUITE("Uci Engine Communication Tests") {
 
         engine::UciEngine uci_engine = engine::UciEngine(config, false);
 
-        CHECK(uci_engine.start());
+        CHECK(uci_engine.start(/*cpus*/ std::nullopt));
 
         CHECK(uci_engine.output().size() == 12);
         CHECK(uci_engine.output()[0].line == "argv[1]: arg1");
@@ -129,7 +129,7 @@ TEST_SUITE("Uci Engine Communication Tests") {
 
         engine::UciEngine uci_engine = engine::UciEngine(config, false);
 
-        CHECK(uci_engine.start());
+        CHECK(uci_engine.start(/*cpus*/ std::nullopt));
 
         CHECK(uci_engine.writeEngine("uci"));
         const auto res = uci_engine.readEngine("uciok");
@@ -171,7 +171,7 @@ TEST_SUITE("Uci Engine Communication Tests") {
 
         std::unique_ptr<engine::UciEngine> uci_engine = std::make_unique<MockUciEngine>(config, false);
 
-        CHECK(uci_engine->start());
+        CHECK(uci_engine->start(/*cpus*/ std::nullopt));
 
         CHECK(uci_engine->writeEngine("uci"));
         const auto res = uci_engine->readEngine("uciok");
@@ -190,7 +190,7 @@ TEST_SUITE("Uci Engine Communication Tests") {
 
         uci_engine = std::make_unique<MockUciEngine>(config, false);
 
-        CHECK(uci_engine->start());
+        CHECK(uci_engine->start(/*cpus*/ std::nullopt));
 
         CHECK(uci_engine->writeEngine("uci"));
         const auto res2 = uci_engine->readEngine("uciok");
@@ -214,7 +214,7 @@ TEST_SUITE("Uci Engine Communication Tests") {
 
         std::unique_ptr<engine::UciEngine> uci_engine = std::make_unique<MockUciEngine>(config, false);
 
-        CHECK(uci_engine->start());
+        CHECK(uci_engine->start(/*cpus*/ std::nullopt));
 
         CHECK(uci_engine->writeEngine("uci"));
         const auto res = uci_engine->readEngine("uciok");
@@ -233,7 +233,7 @@ TEST_SUITE("Uci Engine Communication Tests") {
 
         uci_engine = std::make_unique<MockUciEngine>(config, false);
 
-        CHECK(uci_engine->start());
+        CHECK(uci_engine->start(/*cpus*/ std::nullopt));
 
         CHECK(uci_engine->writeEngine("uci"));
         const auto res2 = uci_engine->readEngine("uciok");
@@ -263,7 +263,7 @@ TEST_SUITE("Uci Engine Communication Tests") {
 
         std::unique_ptr<engine::UciEngine> uci_engine = std::make_unique<MockUciEngine>(config, false);
 
-        CHECK(uci_engine->start());
+        CHECK(uci_engine->start(/*cpus*/ std::nullopt));
 
         CHECK(uci_engine->refreshUci());
         const auto res = uci_engine->readEngine("option set: setoption name UCI_Chess960");


### PR DESCRIPTION
Fixes #922.

The previous approach has a couple of issues:
1. The `setAffinity` function (as written) on Windows only works for setting process affinity, not for setting thread affinity. For thread affinity, a different set of Windows APIs needs to be used. However, the function is used for setting thread affinity (in `BaseTournament::playGame`).
2. In `BaseTournament::playGame`, the return code of `setAffinity` was not checked, so even though this call always fails on Windows, the failure was ignored.
3. On Windows, child processes inherit their parent process's affinity, not the affinity of the thread from which they were created. So even if the tournament thread's affinity is set correctly, it won't propagate to the engine processes.

In other words: the logic from #867 simply doesn't apply to Windows. The logic there assumes the Linux model of affinities, where (IIUC) affinity is a thread-level property, processes only have an affinity insofar as their main thread does, and threads inherit their affinity from parent threads, even across process boundaries.

In this PR I fix this by:
 - Splitting `setAffinity` into `setThreadAffinity` and `setProcessAffinity` so that semantics on different platforms can be correctly represented. On Linux, `setProcessAffinity` can simply call `setThreadAffinity`, which will set the affinity of the process's main thread (the existing behavior).
 - Explicitly setting process affinity as part of starting the engine processes in `UciEngine::start`. On Linux this shouldn't have any effect if the tournament's thread affinity is already set.
 - Adding error logging to `BaseTournament::playGame` so that failure to set thread affinity isn't silently ignored
 - Making all `affinity::` functions `[[nodiscard]]`

Additionally, the Makefile is modified to use static linking on Windows for debug builds. It might just be how my environment is set up, but when building in debug mode (with msys2 and ucrt64), I wasn't able to run the resulting binary because it couldn't find the required DLLs. Making the build static fixes this problem, making debugging easier. Note that under release we always produce a statically linked binary regardless.

Testing done:
 - Verified that CPU affinity is respected for a test tournament with my engine Euwe (using concurrency of 64 on a 64 core / 128 thread processor):
    <img width="1058" height="879" alt="image" src="https://github.com/user-attachments/assets/6b7a0925-fd6d-4327-b21f-2dd341b41f83" />
 - Verified the same is true for a tournament between instances of Stockfish 17.
 - Ran unit tests on WSL (still can't figure out how to make those run on Windows.).