### PR TITLE
bugfix: gettid is not available in older glibc versions

### DIFF
--- a/app/src/affinity/affinity.hpp
+++ b/app/src/affinity/affinity.hpp
@@ -12,6 +12,7 @@
 #else
 #    include <sched.h>
 #    include <unistd.h>
+#    include <sys/syscall.h>
 #endif
 
 namespace fastchess {
@@ -168,7 +169,7 @@ template <typename F>
     // dummy
     return 0;
 #    else
-    return gettid();
+    return static_cast<pid_t>(syscall(SYS_gettid));
 #    endif
 }
 #endif


### PR DESCRIPTION
I understand this to produce identical results; and that gettid() is simply a wrapper for syscall(SYS_gettid) on Linux. I could be mistaken, so do check however you would normally.