### PR TITLE
fix: add static linking for default Windows builds

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -102,9 +102,11 @@ MKDIR	  := mkdir -p
 
 ifeq ($(OS), Windows_NT)
 	uname_S  := Windows
+	LDFLAGS := -static
 else
 ifeq ($(COMP), MINGW)
 	uname_S  := Windows
+	LDFLAGS := -static
 else
 	SUFFIX  :=
 	LDFLAGS := -pthread -lstdc++fs
@@ -114,9 +116,6 @@ endif
 
 ifeq ($(build), debug)
 	CXXFLAGS := -O0 -std=c++17 -Wall -Wextra -pedantic -Wuninitialized -g3 -D_GLIBCXX_ASSERTIONS
-	ifeq ($(uname_S), Windows)
-		LDFLAGS += -static
-	endif
 endif
 
 ifeq ($(build), release)


### PR DESCRIPTION
## Summary

The default Windows build was missing the `-static` linker flag, causing the binary to depend on MSYS64 UCRT runtime DLLs. This caused runtime errors when running the binary outside the MSYS64 environment:

```
fastchess.exe - Entry Point Not Found
The procedure entry point nanosleep64 could not be located in the dynamic link library
```

When used by Fishtest worker, this manifested as:
```
Fatal; Base-xxx engine startup failure: Engine didn't respond to uciok after startup
```

The `build=debug` and `build=release` targets already had static linking, but the default build (used by Fishtest worker's `setup_fastchess` function) did not.

## Changes

- Add `LDFLAGS := -static` for `Windows_NT` and `MINGW` default builds
- Remove redundant `-static` from debug build section (now set by default for all Windows builds)

## Impact

- Binary size increases from ~4.1 MB to ~7.0 MB due to static linking
- The executable now runs correctly on any Windows system without requiring MSYS64 DLLs in PATH
- Fixes compatibility with Fishtest worker on Windows when using MSYS64/UCRT64 toolchain