### PR TITLE
fix: only parse sdout for uci

### DIFF
--- a/app/src/engine/uci_engine.hpp
+++ b/app/src/engine/uci_engine.hpp
@@ -143,6 +143,19 @@ class UciEngine {
     void loadConfig(const EngineConfiguration& config);
     void sendSetoption(const std::string& name, const std::string& value);
 
+    std::vector<const process::Line*> getLines(process::Standard type) const {
+        std::vector<const process::Line*> lines;
+        for (const auto& line : output_) {
+            if (line.std == type) {
+                lines.push_back(&line);
+            }
+        }
+        return lines;
+    }
+
+    std::vector<const process::Line*> getStdoutLines() const { return getLines(process::Standard::OUTPUT); }
+    std::vector<const process::Line*> getStderrLines() const { return getLines(process::Standard::ERR); }
+
     process::Process process_ = {};
     UCIOptions uci_options_   = {};
     EngineConfiguration config_;


### PR DESCRIPTION
uci protocol is only limited to stdout but some engines might send stderr output as well, this could be sometimes the case while trying to parse uci options which causes an exception in fastchess

add getStdoutLines() and getStderrLines() functions to parse the correct output