### PR TITLE
fix: safer uci parsing & set result for exceptions

### DIFF
--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -425,7 +425,8 @@ std::optional<std::string> UciEngine::bestmove() const {
     const auto bm = str_utils::findElement<std::string>(str_utils::splitString(lines.back()->line, ' '), "bestmove");
 
     if (!bm.has_value()) {
-        Logger::print<Logger::Level::WARN>("Warning; No bestmove found in the last line from {}", config_.name);
+        Logger::print<Logger::Level::WARN>("Warning; No bestmove found in the last line from {} because: {}",
+                                           config_.name, bm.error());
 
         return std::nullopt;
     }

--- a/app/tests/functions_test.cpp
+++ b/app/tests/functions_test.cpp
@@ -23,4 +23,10 @@ TEST_SUITE("Standalone Function Tests") {
 
         CHECK(!str_utils::findElement<std::string>(str_utils::splitString(str, ' '), "bestmove").has_value());
     }
+
+    TEST_CASE("Dont Throw Exception on Missing Element") {
+        const auto str = "info depth 1 seldepth  score cp  nodes  nps 0 hashfull 0 time 0 pv e4d5";
+
+        CHECK(!str_utils::findElement<int64_t>(str_utils::splitString(str, ' '), "score").has_value());
+    }
 }


### PR DESCRIPTION
- avoids throwing an exception in findElement for invalid uci output
- correctly sets the losing side in case any exception still gets through

fixes https://github.com/Disservin/fastchess/issues/977