### PR TITLE
refactor: make termination of engines happen in parallel

### DIFF
--- a/app/src/core/memory/cache.hpp
+++ b/app/src/core/memory/cache.hpp
@@ -61,14 +61,9 @@ class CachePool {
         cache_.erase(it);
     }
 
-    auto size() {
-        std::lock_guard<std::mutex> lock(access_mutex_);
-        return cache_.size();
-    }
-
     void loopEntries(const std::function<void(typename std::list<CachedEntry<T, ID>>::iterator&)>& func) {
         std::lock_guard<std::mutex> lock(access_mutex_);
-        for (auto it = cache_.begin(); it != cache_.end(); ++it) {  // Added ++it
+        for (auto it = cache_.begin(); it != cache_.end(); ++it) { 
             func(it);
         }
     }

--- a/app/src/core/memory/cache.hpp
+++ b/app/src/core/memory/cache.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <functional>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -58,6 +59,18 @@ class CachePool {
         assert(!it->available_);
         std::lock_guard<std::mutex> lock(access_mutex_);
         cache_.erase(it);
+    }
+
+    auto size() {
+        std::lock_guard<std::mutex> lock(access_mutex_);
+        return cache_.size();
+    }
+
+    void loopEntries(const std::function<void(typename std::list<CachedEntry<T, ID>>::iterator&)>& func) {
+        std::lock_guard<std::mutex> lock(access_mutex_);
+        for (auto it = cache_.begin(); it != cache_.end(); ++it) {  // Added ++it
+            func(it);
+        }
     }
 
    private:

--- a/app/src/core/memory/scope_guard.hpp
+++ b/app/src/core/memory/scope_guard.hpp
@@ -12,6 +12,7 @@ class ScopeEntry {
     ScopeEntry(bool available) : available_(available) {}
 
     void release() noexcept { available_ = true; }
+    bool isAvailable() const noexcept { return available_.load(); }
 
    protected:
     std::atomic<bool> available_;

--- a/app/src/engine/process/iprocess.hpp
+++ b/app/src/engine/process/iprocess.hpp
@@ -66,7 +66,7 @@ class IProcess {
     // Write input to the engine's stdin
     virtual Result writeInput(const std::string& input) noexcept = 0;
 
-    constexpr static std::chrono::seconds kill_timeout{60};
+    constexpr static std::chrono::seconds kill_timeout{5};
 
    protected:
     [[nodiscard]] std::string getPath(const std::string& dir, const std::string& cmd) const {

--- a/app/src/engine/process/iprocess.hpp
+++ b/app/src/engine/process/iprocess.hpp
@@ -66,7 +66,7 @@ class IProcess {
     // Write input to the engine's stdin
     virtual Result writeInput(const std::string& input) noexcept = 0;
 
-    constexpr static std::chrono::seconds kill_timeout{5};
+    constexpr static std::chrono::seconds kill_timeout{10};
 
    protected:
     [[nodiscard]] std::string getPath(const std::string& dir, const std::string& cmd) const {

--- a/app/src/engine/process/process_posix.hpp
+++ b/app/src/engine/process/process_posix.hpp
@@ -209,6 +209,9 @@ class Process : public IProcess {
     }
 
     Result alive() noexcept override {
+        if (terminated_) return Result::Error("process terminated");
+        if (startup_error_) return Result::Error("process failed to start");
+
         assert(is_initalized_);
 
         int status    = 0;
@@ -249,6 +252,7 @@ class Process : public IProcess {
         // log the status of the process
         Logger::readFromEngine(signalToString(status), time::datetime_precise(), log_name_, true);
         is_initalized_ = false;
+        terminated_    = true;
     }
 
     void setupRead() override {
@@ -461,6 +465,7 @@ class Process : public IProcess {
 
     bool is_initalized_ = false;
     bool startup_error_ = false;
+    bool terminated_    = false;
 
     pid_t process_pid_{0};
     Pipe in_pipe_, out_pipe_, err_pipe_;

--- a/app/src/engine/process/process_win.hpp
+++ b/app/src/engine/process/process_win.hpp
@@ -133,12 +133,7 @@ class Process : public IProcess {
         // give the process time to die gracefully
         while (std::chrono::steady_clock::now() - start_time < IProcess::kill_timeout) {
             GetExitCodeProcess(pi_.hProcess, &exitCode);
-
-            if (exitCode != STILL_ACTIVE) {
-                // Process has terminated
-                break;
-            }
-
+            if (exitCode != STILL_ACTIVE) break;
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
 

--- a/app/src/engine/process/process_win.hpp
+++ b/app/src/engine/process/process_win.hpp
@@ -102,6 +102,8 @@ class Process : public IProcess {
     }
 
     [[nodiscard]] Result alive() noexcept override {
+        if (terminated_) return Result::Error("process terminated");
+
         assert(is_initialized_);
 
         DWORD exitCode = 0;
@@ -150,6 +152,7 @@ class Process : public IProcess {
         }
 
         is_initialized_ = false;
+        terminated_     = true;
     }
 
     void setupRead() override { current_line_.clear(); }
@@ -354,6 +357,7 @@ class Process : public IProcess {
 
     // True if the process has been initialized
     bool is_initialized_ = false;
+    bool terminated_     = false;
 
     PROCESS_INFORMATION pi_;
 

--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -266,6 +266,10 @@ void UciEngine::loadConfig(const EngineConfiguration& config) { config_ = config
 void UciEngine::quit() {
     if (!initialized_) return;
 
+    if (!process_.alive()) return;
+
+    LOG_TRACE_THREAD("Trying to stop engine gracefully {}", config_.name);
+
     if (!writeEngine("stop")) {
         LOG_WARN_THREAD("Failed to send stop to engine {}", config_.name);
     }

--- a/app/src/engine/uci_engine.hpp
+++ b/app/src/engine/uci_engine.hpp
@@ -36,6 +36,8 @@ class UciEngine {
 
     ~UciEngine() { quit(); }
 
+    void terminate() { process_.terminate(); }
+
     // Starts the engine, does nothing after the first call.
     // Returns false if the engine is not alive.
     [[nodiscard]] tl::expected<bool, std::string> start(const std::optional<std::vector<int>>& cpus);

--- a/app/src/matchmaking/tournament/base/tournament.cpp
+++ b/app/src/matchmaking/tournament/base/tournament.cpp
@@ -83,39 +83,32 @@ BaseTournament::~BaseTournament() {
         }
     }
 
-    std::lock_guard<std::mutex> lock(cache_management_mutex_);
-
     // loop over the individual engine caches and enqueue a terminate to the pool
     // to ensure all engines are properly shutdown, without having to wait sequentially
-
+    std::lock_guard<std::mutex> lock(cache_management_mutex_);
     std::vector<engine::UciEngine*> engines_to_terminate;
 
-    if (config::TournamentConfig->affinity) {
-        for (const auto& [tid, cache] : thread_caches_) {
-            cache->loopEntries([&engines_to_terminate](auto& it) {
-                if (it->isAvailable() == false) {
-                    Logger::print<Logger::Level::WARN>(
-                        "Unexpected; Engine still in use during tournament shutdown, please raise an issue.");
-                    return;
-                }
+    static constexpr auto error = "Unexpected; Engine still in use during tournament shutdown, please raise an issue.";
 
-                engines_to_terminate.push_back(it->get().get());
-            });
+    const auto appendToList = [&engines_to_terminate](auto& it) {
+        if (it->isAvailable() == false) {
+            Logger::print<Logger::Level::WARN>(error);
+            return;
         }
-    } else if (global_cache_) {
-        global_cache_->loopEntries([&engines_to_terminate](auto& it) {
-            if (it->isAvailable() == false) {
-                Logger::print<Logger::Level::WARN>(
-                    "Unexpected; Engine still in use during tournament shutdown, please raise an issue.");
-                return;
-            }
 
-            engines_to_terminate.push_back(it->get().get());
-        });
-    }
+        engines_to_terminate.push_back(it->get().get());
+    };
 
-    // parallel terminate engines
+    if (config::TournamentConfig->affinity)
+        for (const auto& [_, cache] : thread_caches_)  //
+            cache->loopEntries(appendToList);
+    else if (global_cache_)
+        global_cache_->loopEntries(appendToList);
+
+    // parallel terminate engines. might be more than concurrency but doesn't matter
+    // since they arent doing much
     std::vector<std::thread> threads;
+
     for (auto* engine : engines_to_terminate) {
         threads.emplace_back([engine]() {
             engine->quit();
@@ -124,9 +117,8 @@ BaseTournament::~BaseTournament() {
         });
     }
 
-    for (auto& t : threads) {
+    for (auto& t : threads)
         if (t.joinable()) t.join();
-    }
 
     saveJson();
 }


### PR DESCRIPTION
in case a lot of engines dont respond anymore and need to be sigkilled we sequentially waited 60s for each engine, with a lot of engines this makes us wait a really long

now terminate the engines in parallel, so that terminations after at most 10s