### PR TITLE
[bugfix] check bestmove only for multipv 1 lines

### DIFF
--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -661,11 +661,23 @@ void Match::verifyPvLines(const Player& us) {
     // finally check if the final PV matches bestmove
     const auto best_move = us.engine.bestmove();
 
-    // skip the check if the final score is upperbound/lowerbound
-    const auto& info   = info_lines.back();
-    const auto isBound = engine::UciEngine::isBound(*info);
-    const auto pv      = engine::UciEngine::getPv(*info);
-    if (isBound || !pv.has_value() || pv->empty() || !best_move.has_value()) {
+    if (!best_move.has_value()) {
+        return;
+    }
+
+    // find the correct info line: search backwards for multipv 1 or no multipv
+    const auto it = std::find_if(info_lines.rbegin(), info_lines.rend(), [](const auto* line) {
+        return line->find(" multipv ") == std::string::npos || line->find(" multipv 1 ") != std::string::npos;
+    });
+
+    if (it == info_lines.rend()) {
+        return;
+    }
+
+    const auto& info   = **it;
+    const auto isBound = engine::UciEngine::isBound(info);
+    const auto pv      = engine::UciEngine::getPv(info);
+    if (isBound || !pv.has_value() || pv->empty()) {
         return;
     }
 
@@ -673,7 +685,7 @@ void Match::verifyPvLines(const Player& us) {
         auto warning   = "Warning; Bestmove does not match beginning of last PV - move {} from {}";
         auto start_pos = start_position_ == "startpos" ? "startpos" : ("fen " + start_position_);
         auto out       = fmt::format(fmt::runtime(warning), best_move.value(), us.engine.getConfig().name);
-        auto uci_info  = fmt::format("Info; {}", *info);
+        auto uci_info  = fmt::format("Info; {}", info);
         auto position  = fmt::format("Position; {}", start_pos);
         auto ucimoves  = fmt::format("Moves; {}", str_utils::join(uci_moves_, " "));
 


### PR DESCRIPTION
Fixes #998.

Master:
```
> ./fastchess -engine name=sf-dev1 cmd=./stockfish option.'MultiPV'=2 -engine name=sf-dev2 cmd=./stockfish option.'Skill Level'=10 -each tc=0.2+0.01 -rounds 5 -concurrency -1 -openings file=UHO_Lichess_4852_v1.epd format=epd > fc_master.txt
> grep Warning fc_master.txt | grep -c sf-dev1 
573
> grep Warning fc_master.txt | grep -c sf-dev2 
215
```

Patch:
```
> ./fastchess -engine name=sf-dev1 cmd=./stockfish option.'MultiPV'=2 -engine name=sf-dev2 cmd=./stockfish option.'Skill Level'=10 -each tc=0.2+0.01 -rounds 5 -concurrency -1 -openings file=UHO_Lichess_4852_v1.epd format=epd > fc_patch.txt
> grep Warning fc_patch.txt | grep -c sf-dev1
0
> grep Warning fc_patch.txt | grep -c sf-dev2
259
```

So the output shows that both correctly report bestmove mismatch for sf-dev with skill levels, while only master reports wrong bestmove for sf-dev in multiPV mode.