### PR TITLE
Fix extra initial newline in PGN writing

### DIFF
--- a/app/src/game/pgn/pgn_gen.hpp
+++ b/app/src/game/pgn/pgn_gen.hpp
@@ -71,7 +71,7 @@ class PGNGenerator {
         auto appendText = [&](const std::string& text) {
             // Check if adding this text exceeds 80 chars
             // +1 accounts for the space we might add
-            if (currentLineLength + text.length() + (currentLineLength > 0 ? 1 : 0) > 80) {
+            if (currentLineLength > 0 && currentLineLength + text.length() + 1 > 80) {
                 ss << "\n";
                 currentLineLength = 0;
             }


### PR DESCRIPTION
If the initial line is > 80 characters, then a leading newline is added, leading to multiple new lines between the headers and body of the PGN, which breaks the spec., and breaks python-chess at least. PR fixes it. 

This is technically going to be a breaking change for OpenBench. I don't have a great mechanism to force update other than the version value. So if its immaterial to you, bumping the version to 1.8.1 would help me. If not, then I'll go and get some versioning more granular. 