### PR TITLE
add warning for mismatching mate scores

### DIFF
--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -302,6 +302,30 @@ bool Match::playMove(Player& us, Player& them) {
         return false;
     }
 
+    auto usScore   = us.engine.lastScore();
+    auto themScore = them.engine.lastScore();
+
+    if (usScore.has_value() && themScore.has_value() && usScore.value().type == engine::ScoreType::MATE &&
+        themScore.value().type == engine::ScoreType::MATE) {
+        auto usMate   = usScore.value().value;
+        auto themMate = themScore.value().value;
+
+        // if both engines claim to have a proven win, only one of them can be right (same for loss)
+        if (usMate * themMate > 0) {
+            auto warning   = "Warning; Sign mismatch in mate scores {} and {} from {} and {}";
+            auto start_pos = start_position_ == "startpos" ? "startpos" : ("fen " + start_position_);
+            auto out       = fmt::format(fmt::runtime(warning), usMate, themMate, us.engine.getConfig().name,
+                                         them.engine.getConfig().name);
+            auto uci_info  = fmt::format("Infos; {} ; {}", us.engine.lastInfoLine(), them.engine.lastInfoLine());
+            auto position  = fmt::format("Position; {}", start_pos);
+            auto ucimoves  = fmt::format("Moves; {}", str_utils::join(uci_moves_, " "));
+
+            auto separator = config::TournamentConfig->test_env ? " :: " : "\n";
+
+            Logger::print<Logger::Level::WARN>("{1}{0}{2}{0}{3}{0}{4}", separator, out, uci_info, position, ucimoves);
+        }
+    }
+
     // make sure adjudicate is placed after normal termination as it has lower priority
     if (adjudicate(them, us)) {
         return false;

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -418,17 +418,44 @@ bool Match::playMove(Player& us, Player& them) {
     // into account the fullmove counter of the starting FEN, leading to different behavior between
     // pgn and epd adjudication. fastchess fixes this by using the fullmove counter from the board
     // object directly
-    auto score = us.engine.lastScore();
+    auto usScore = us.engine.lastScore();
 
-    if (score.has_value()) {
-        draw_tracker_.update(score.value(), board_.halfMoveClock());
-        resign_tracker_.update(score.value(), ~board_.sideToMove());
+    if (usScore.has_value()) {
+        draw_tracker_.update(usScore.value(), board_.halfMoveClock());
+        resign_tracker_.update(usScore.value(), ~board_.sideToMove());
     } else {
         draw_tracker_.invalidate();
         resign_tracker_.invalidate(~board_.sideToMove());
     }
 
     maxmoves_tracker_.update();
+
+    // if both engines have made a move in this game, we perform a sanity check on their scores
+    auto themScore =
+        uci_moves_.size() > 1 ? them.engine.lastScore() : tl::make_unexpected(std::string("No score yet"));
+
+    if (themScore.has_value() && usScore.has_value() && themScore.value().type == engine::ScoreType::MATE &&
+        usScore.value().type == engine::ScoreType::MATE) {
+        auto themMate = themScore.value().value;
+        auto usMate   = usScore.value().value;
+
+        // if both engines claim to have a proven win, only one of them can be right (same for loss)
+        if (usMate * themMate > 0) {
+            auto themColor = board_.sideToMove() == Color::WHITE ? "White" : "Black";
+            auto usColor   = board_.sideToMove() == Color::WHITE ? "Black" : "White";
+            auto warning   = "Warning; Sign mismatch in mate scores {} and {} from {} ({}) and {} ({})";
+            auto start_pos = start_position_ == "startpos" ? "startpos" : ("fen " + start_position_);
+            auto out = fmt::format(fmt::runtime(warning), themMate, usMate, them.engine.getConfig().name, themColor,
+                                   us.engine.getConfig().name, usColor);
+            auto uci_info = fmt::format("Infos; {} ; {}", them.engine.lastInfoLine(), us.engine.lastInfoLine());
+            auto position = fmt::format("Position; {}", start_pos);
+            auto ucimoves = fmt::format("Moves; {}", str_utils::join(uci_moves_, " "));
+
+            auto separator = config::TournamentConfig->test_env ? " :: " : "\n";
+
+            Logger::print<Logger::Level::WARN>("{1}{0}{2}{0}{3}{0}{4}", separator, out, uci_info, position, ucimoves);
+        }
+    }
 
     return true;
 }


### PR DESCRIPTION
This PR emits a warning if both engines claim to have found a proven win, and same for a proven loss. Of course, this can only happen if one of the two engines is buggy, or if the first engine sent a `bestmove` that does not correspond to the (winning) mate score.

I prefixed the warning line that contains both info lines with `Infos;`. Let me know if this should be changed.

Example: (edited to reflect latest commit)
```
Warning; Sign mismatch in mate scores 32 and 6 from winter (White) and sf-dev (Black)
Infos; info depth 9 seldepth 16 time 23 nodes 16287 nps 678625 score mate 32 wdl 0 0 1000 pv g2g3 c6d6 g3h3 d6f4 h3h4 g7g5 h4h3 f4f3 f1g3 f3g4 ; info depth 12 seldepth 12 multipv 1 score mate 6 nodes 2688 nps 896000 hashfull 0 tbhits 0 time 3 pv c6c5 f1e3 c5e3 h2h3 e3f2 g3f4 f2h2 f4g5 h2e5 g5h4 g7g5
Position; fen rnbqk1nr/pppp1ppp/3b4/4p3/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3
Moves; e5d4 f3d4 g8f6 d4f5 d6f8 f1d3 d7d5 e4d5 d8d5 f5e3 d5e5 e1g1 f8d6 g2g3 e8g8 b1d2 b8c6 d2c4 e5e7 f1e1 f8e8 c4d6 e7d6 b2b3 d6e5 c1a3 c8h3 d1f3 e5c3 f3f4 c6d4 e1d1 a8d8 e3c4 d4e2 d3e2 d8d1 a1d1 e8e2 d1f1 e2e1 c4e3 h3f1 e3f1 c3c2 f4b4 e1e8 b4b7 a7a6 b7a6 c2a2 a6a5 f6e4 a5f5 a2a3 f5d7 e4f6 d7c6 a3b3 g1g2 b3d5 f2f3 d5c6 g3g4 e8e2 g2g3 c6c5
```