### PR TITLE
Tighten bestmove extraction

### DIFF
--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -436,16 +436,22 @@ std::optional<std::string> UciEngine::bestmove() const {
     const auto lines = getStdoutLines();
     if (lines.empty()) {
         Logger::print<Logger::Level::WARN>("Warning; No output from {}", config_.name);
-
         return std::nullopt;
     }
 
-    const auto bm = str_utils::findElement<std::string>(str_utils::splitString(lines.back()->line, ' '), "bestmove");
+    const auto& last_line = lines.back()->line;
+
+    if (last_line.rfind("bestmove", 0) != 0) {
+        Logger::print<Logger::Level::WARN>("Warning; No bestmove found in the last line from {} because: {}",
+                                           config_.name, "Line does not start with 'bestmove'");
+        return std::nullopt;
+    }
+
+    const auto bm = str_utils::findElement<std::string>(str_utils::splitString(last_line, ' '), "bestmove");
 
     if (!bm.has_value()) {
         Logger::print<Logger::Level::WARN>("Warning; No bestmove found in the last line from {} because: {}",
                                            config_.name, bm.error());
-
         return std::nullopt;
     }
 
@@ -525,7 +531,7 @@ std::optional<std::vector<std::string>> UciEngine::getPv(std::string_view info_l
 
 bool UciEngine::outputIncludesBestmove() const {
     for (const auto& line : getStdoutLines()) {
-        if (line->line.find("bestmove") != std::string::npos) return true;
+        if (line->line.rfind("bestmove", 0) == 0) return true;
     }
 
     return false;

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -330,7 +330,7 @@ bool Match::playMove(Player& us, Player& them) {
     // prepare the engine for reading
     us.engine.setupReadEngine();
 
-    // wait for bestmove
+    // wait for output line starting with "bestmove"
     const auto t0     = clock::now();
     const auto status = us.engine.readEngineLowLat("bestmove", us.getTimeoutThreshold());
     const auto t1     = clock::now();


### PR DESCRIPTION
If nothing else, this PR makes it crystal clear in all parts of the code that a valid bestmove output must have `bestmove` at the start of the output line.