### PR TITLE
Only send warning about missing bestmove if engine did not timeout

### DIFF
--- a/app/src/engine/uci_engine.cpp
+++ b/app/src/engine/uci_engine.cpp
@@ -432,32 +432,42 @@ bool UciEngine::writeEngine(const std::string& input) {
     return process_.writeInput(input + "\n").code == process::Status::OK;
 }
 
-std::optional<std::string> UciEngine::bestmove() const {
+std::optional<std::string> UciEngine::bestmove(bool warn_on_error) const {
+    const auto warn = [&](std::string_view reason, std::string_view last_line = {}) {
+        if (!warn_on_error) {
+            return;
+        }
+
+        if (last_line.empty()) {
+            Logger::print<Logger::Level::WARN>("Warning; No output from {}", config_.name);
+        } else {
+            Logger::print<Logger::Level::WARN>("Warning; No bestmove found from {} because: {}. Last line was: {}",
+                                               config_.name, reason, last_line);
+        }
+    };
+
     const auto lines = getStdoutLines();
+
     if (lines.empty()) {
-        Logger::print<Logger::Level::WARN>("Warning; No output from {}", config_.name);
+        warn("No output");
         return std::nullopt;
     }
 
     const auto& last_line = lines.back()->line;
 
     if (last_line.rfind("bestmove", 0) != 0) {
-        Logger::print<Logger::Level::WARN>(
-            "Warning; No bestmove found in the last line from {} because: {}. Last line was: {}", config_.name,
-            "Line does not start with 'bestmove'", last_line);
+        warn("Line does not start with 'bestmove'", last_line);
         return std::nullopt;
     }
 
     const auto bm = str_utils::findElement<std::string>(str_utils::splitString(last_line, ' '), "bestmove");
 
     if (!bm.has_value()) {
-        Logger::print<Logger::Level::WARN>(
-            "Warning; No bestmove found in the last line from {} because: {}. Last line was: {}", config_.name,
-            bm.error(), last_line);
+        warn(bm.error(), last_line);
         return std::nullopt;
     }
 
-    return bm.value();
+    return *bm;
 }
 
 std::chrono::milliseconds UciEngine::lastTime() const {

--- a/app/src/engine/uci_engine.hpp
+++ b/app/src/engine/uci_engine.hpp
@@ -108,7 +108,7 @@ class UciEngine {
     }
 
     // Get the bestmove from the last output.
-    [[nodiscard]] std::optional<std::string> bestmove() const;
+    [[nodiscard]] std::optional<std::string> bestmove(bool warn_on_error = true) const;
 
     // Get the last info line from the last output.
     [[nodiscard]] std::string lastInfoLine() const;

--- a/app/src/matchmaking/match/match.cpp
+++ b/app/src/matchmaking/match/match.cpp
@@ -368,7 +368,7 @@ bool Match::playMove(Player& us, Player& them) {
         LOG_INFO_THREAD("Engine {} latency: {}ms (elapsed: {}, reported: {})", name, latency, elapsed_ms, last_time);
     }
 
-    const auto best_move = us.engine.bestmove();
+    const auto best_move = us.engine.bestmove(status.code == engine::process::Status::OK);
     const auto move      = best_move && uci::isUciMove(*best_move) ? uci::uciToMove(board_, *best_move) : Move::NO_MOVE;
     const auto legal     = isLegal(move);
 


### PR DESCRIPTION
No longer send warnings about bestmove extraction if the engine timed out.

I believe this fixes the root cause of those spurious bestmove extraction warnings on fishtest.