### PR TITLE
feat: better engine name defaults

### DIFF
--- a/app/src/cli/sanitize.cpp
+++ b/app/src/cli/sanitize.cpp
@@ -5,7 +5,6 @@
 #include <thread>
 #include <utility>
 #include <vector>
-#include <filesystem>
 
 #include <core/filesystem/fd_limit.hpp>
 #include <core/filesystem/file_system.hpp>
@@ -116,16 +115,6 @@ void validateEngine(EngineConfiguration& config) {
     }
 #endif
 
-    if (config.name.empty()) {
-        // strip directory and extension
-        std::filesystem::path p(config.cmd);
-        config.name = p.stem().string();
-    }
-    
-    if (config.name.empty()) {
-        throw fastchess_exception("Error; please specify a name for each engine!");
-    }
-
     if ((config.limit.tc.time + config.limit.tc.increment) == 0 && config.limit.tc.fixed_time == 0 &&
         config.limit.nodes == 0 && config.limit.plies == 0) {
         throw fastchess_exception("Error; no TimeControl specified!");
@@ -146,7 +135,17 @@ void validateEngine(EngineConfiguration& config) {
             throw fastchess_exception("Engine binary does not exist: " + enginePath.string());
         }
     }
+
+    if (config.name.empty()) {
+        // strip directory and extension
+        std::filesystem::path p(config.cmd);
+        config.name = p.stem().string();
+    }
 #endif
+    
+    if (config.name.empty()) {
+        throw fastchess_exception("Error; please specify a name for each engine!");
+    }
 }
 
 }  // namespace
@@ -168,7 +167,7 @@ void sanitize(std::vector<EngineConfiguration>& configs) {
 
         for (std::size_t j = 0; j < i; j++) {
             if (configs[i].name == configs[j].name) {
-                throw fastchess_exception("Error: Engine with the same name are not allowed!: " + configs[i].name);
+                configs[i].name += "_" + std::to_string(i);
             }
         }
     }

--- a/app/src/cli/sanitize.cpp
+++ b/app/src/cli/sanitize.cpp
@@ -165,9 +165,10 @@ void sanitize(std::vector<EngineConfiguration>& configs) {
     for (std::size_t i = 0; i < configs.size(); i++) {
         validateEngine(configs[i]);
 
+        int suffix = 2;
         for (std::size_t j = 0; j < i; j++) {
             if (configs[i].name == configs[j].name) {
-                configs[i].name += "_" + std::to_string(i);
+                configs[i].name += "_" + std::to_string(suffix++);
             }
         }
     }

--- a/app/src/cli/sanitize.cpp
+++ b/app/src/cli/sanitize.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <utility>
 #include <vector>
+#include <filesystem>
 
 #include <core/filesystem/fd_limit.hpp>
 #include <core/filesystem/file_system.hpp>
@@ -115,6 +116,12 @@ void validateEngine(EngineConfiguration& config) {
     }
 #endif
 
+    if (config.name.empty()) {
+        // strip directory and extension
+        std::filesystem::path p(config.cmd);
+        config.name = p.stem().string();
+    }
+    
     if (config.name.empty()) {
         throw fastchess_exception("Error; please specify a name for each engine!");
     }

--- a/app/tests/cli_test.cpp
+++ b/app/tests/cli_test.cpp
@@ -160,17 +160,6 @@ TEST_SUITE("Option Parsing Tests") {
                              fastchess_exception);
     }
 
-    TEST_CASE("Should throw no engine name") {
-        const auto args = cli::Args{
-            "fastchess.exe",    "-engine", "dir=./", "cmd=app/tests/mock/engine/dummy_engine",
-            "depth=5",          "-engine", "dir=./", "cmd=app/tests/mock/engine/dummy_engine",
-            "tc=40/1:9.65+0.1",
-        };
-
-        CHECK_THROWS_WITH_AS(cli::OptionsParser{args}, "Error; please specify a name for each engine!",
-                             fastchess_exception);
-    }
-
     TEST_CASE("Should throw invalid tc") {
         const auto args = cli::Args{
             "fastchess.exe",

--- a/app/tests/cli_test.cpp
+++ b/app/tests/cli_test.cpp
@@ -547,8 +547,8 @@ TEST_SUITE("Option Parsing Tests") {
         cli::OptionsParser options = cli::OptionsParser(args);
         auto configs = options.getEngineConfigs();
 
-        CHECK(configs[0].name == "dummy_engine_2");
-        CHECK(configs[1].name == "dummy_engine");
+        CHECK(configs[0].name == "dummy_engine");
+        CHECK(configs[1].name == "dummy_engine_2");
     }
 
     TEST_CASE("Quick option creates two engines and presets tournament") {

--- a/app/tests/cli_test.cpp
+++ b/app/tests/cli_test.cpp
@@ -537,6 +537,20 @@ TEST_SUITE("Option Parsing Tests") {
         CHECK(engines[1].name == "engine2");
     }
 
+    TEST_CASE("Engine name should be auto-assigned and suffixed") {
+        const auto args = cli::Args{
+            "fastchess.exe",    "-engine", "dir=./", "cmd=app/tests/mock/engine/dummy_engine",
+            "depth=5",          "-engine", "dir=./", "cmd=app/tests/mock/engine/dummy_engine",
+            "tc=40/1:9.65+0.1",
+        };
+
+        cli::OptionsParser options = cli::OptionsParser(args);
+        auto configs = options.getEngineConfigs();
+
+        CHECK(configs[0].name == "dummy_engine_2");
+        CHECK(configs[1].name == "dummy_engine");
+    }
+
     TEST_CASE("Quick option creates two engines and presets tournament") {
         const cli::OptionsParser parser{
             buildArgs({"fastchess.exe",

--- a/app/tests/cli_test.cpp
+++ b/app/tests/cli_test.cpp
@@ -188,25 +188,6 @@ TEST_SUITE("Option Parsing Tests") {
         CHECK_THROWS_WITH_AS(cli::OptionsParser{args}, "Error; no TimeControl specified!", fastchess_exception);
     }
 
-    TEST_CASE("Should throw engine with same name") {
-        const auto args = cli::Args{
-            "fastchess.exe",
-            "-engine",
-            "dir=./",
-            "cmd=app/tests/mock/engine/dummy_engine",
-            "tc=10/1+0",
-            "name=Alexandria-EA649FED",
-            "-engine",
-            "dir=./",
-            "cmd=app/tests/mock/engine/dummy_engine",
-            "name=Alexandria-EA649FED",
-            "tc=10/1+0",
-        };
-
-        CHECK_THROWS_WITH_AS(cli::OptionsParser{args},
-                             "Error: Engine with the same name are not allowed!: Alexandria-EA649FED",
-                             fastchess_exception);
-    }
 
     TEST_CASE("Should throw engine with invalid restart") {
         const auto args = cli::Args{


### PR DESCRIPTION
Derive engine name from command when name not given, and add suffix to the engine name in cases where both engines have the same name.

solves https://github.com/Disservin/fastchess/issues/886