### PR TITLE
fix: default engine name when number of engines > 2

### DIFF
--- a/app/src/cli/sanitize.cpp
+++ b/app/src/cli/sanitize.cpp
@@ -166,16 +166,12 @@ void sanitize(std::vector<EngineConfiguration>& configs) {
         validateEngine(configs[i]);
     }
 
-    std::unordered_map<std::string, int> count;
-    for (auto& config : configs) {
-        count[config.name]++;
-    }
-
     std::unordered_map<std::string, int> seen;
     for (auto& config : configs) {
-        if (count[config.name] > 1) {
-            seen[config.name]++;
-            config.name += "_" + std::to_string(seen[config.name]);
+        int& n = seen[config.name];
+    
+        if (n++ > 0) {
+            config.name += "_" + std::to_string(n);
         }
     }
 }

--- a/app/src/cli/sanitize.cpp
+++ b/app/src/cli/sanitize.cpp
@@ -164,12 +164,18 @@ void sanitize(std::vector<EngineConfiguration>& configs) {
 
     for (std::size_t i = 0; i < configs.size(); i++) {
         validateEngine(configs[i]);
+    }
 
-        int suffix = 2;
-        for (std::size_t j = 0; j < i; j++) {
-            if (configs[i].name == configs[j].name) {
-                configs[i].name += "_" + std::to_string(suffix++);
-            }
+    std::unordered_map<std::string, int> count;
+    for (auto& config : configs) {
+        count[config.name]++;
+    }
+
+    std::unordered_map<std::string, int> seen;
+    for (auto& config : configs) {
+        if (count[config.name] > 1) {
+            seen[config.name]++;
+            config.name += "_" + std::to_string(seen[config.name]);
         }
     }
 }

--- a/app/tests/cli_test.cpp
+++ b/app/tests/cli_test.cpp
@@ -541,14 +541,16 @@ TEST_SUITE("Option Parsing Tests") {
         const auto args = cli::Args{
             "fastchess.exe",    "-engine", "dir=./", "cmd=app/tests/mock/engine/dummy_engine",
             "depth=5",          "-engine", "dir=./", "cmd=app/tests/mock/engine/dummy_engine",
-            "tc=40/1:9.65+0.1",
+            "tc=40/1:9.65+0.1", "-engine", "dir=./", "cmd=app/tests/mock/engine/dummy_engine",
+            "tc=40/1:9.65+0.1"
         };
 
         cli::OptionsParser options = cli::OptionsParser(args);
         auto configs = options.getEngineConfigs();
 
-        CHECK(configs[0].name == "dummy_engine");
+        CHECK(configs[0].name == "dummy_engine_1");
         CHECK(configs[1].name == "dummy_engine_2");
+        CHECK(configs[2].name == "dummy_engine_3");
     }
 
     TEST_CASE("Quick option creates two engines and presets tournament") {

--- a/app/tests/cli_test.cpp
+++ b/app/tests/cli_test.cpp
@@ -548,7 +548,7 @@ TEST_SUITE("Option Parsing Tests") {
         cli::OptionsParser options = cli::OptionsParser(args);
         auto configs = options.getEngineConfigs();
 
-        CHECK(configs[0].name == "dummy_engine_1");
+        CHECK(configs[0].name == "dummy_engine");
         CHECK(configs[1].name == "dummy_engine_2");
         CHECK(configs[2].name == "dummy_engine_3");
     }


### PR DESCRIPTION
The original code is flawed when dealing with more than 2 engines that have the same name, this fixes it.