### PR TITLE
feat: default filename for pgnout and epdout

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -202,7 +202,7 @@ void parseEach(const KeyValuePairs& params, ArgumentData& argument_data) {
 }
 
 void parsePgnOut(const KeyValuePairs& params, ArgumentData& argument_data) {
-    argument_data.tournament_config.pgn.file = "fastchess_" + getCurrentTimestampString() + ".pgn";
+    argument_data.tournament_config.pgn.file = "fastchess_" + time::datetime("%Y%m%d_%H%M%S") + ".pgn";
     
     for (const auto& [key, value] : params) {
         if (key == "file") {
@@ -246,7 +246,7 @@ void parsePgnOut(const KeyValuePairs& params, ArgumentData& argument_data) {
 }
 
 void parseEpdOut(const KeyValuePairs& params, ArgumentData& argument_data) {
-    argument_data.tournament_config.epd.file = "fastchess_" + getCurrentTimestampString() + ".epd";
+    argument_data.tournament_config.epd.file = "fastchess_" + time::datetime("%Y%m%d_%H%M%S") + ".epd";
         
     for (const auto& [key, value] : params) {
         if (key == "file") {

--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -79,6 +79,16 @@ std::string concat(const std::vector<std::string>& params) {
     return str;
 }
 
+std::string getCurrentTimestampString() {
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t t = std::chrono::system_clock::to_time_t(now);
+
+    std::ostringstream oss;
+    oss << std::put_time(std::localtime(&t), "%Y%m%d_%H%M%S");
+
+    return oss.str();
+}
+
 bool is_number(const std::string& s) {
     static const auto is_digit = [](unsigned char c) { return !std::isdigit(c); };
     return !s.empty() && std::find_if(s.begin(), s.end(), is_digit) == s.end();
@@ -192,6 +202,8 @@ void parseEach(const KeyValuePairs& params, ArgumentData& argument_data) {
 }
 
 void parsePgnOut(const KeyValuePairs& params, ArgumentData& argument_data) {
+    argument_data.tournament_config.pgn.file = "fastchess_" + getCurrentTimestampString() + ".pgn";
+    
     for (const auto& [key, value] : params) {
         if (key == "file") {
             argument_data.tournament_config.pgn.file = value;
@@ -231,11 +243,11 @@ void parsePgnOut(const KeyValuePairs& params, ArgumentData& argument_data) {
             OptionsParser::throwMissing("pgnout", key, value);
         }
     }
-    if (argument_data.tournament_config.pgn.file.empty())
-        throw fastchess_exception("Please specify filename for pgn output.");
 }
 
 void parseEpdOut(const KeyValuePairs& params, ArgumentData& argument_data) {
+    argument_data.tournament_config.epd.file = "fastchess_" + getCurrentTimestampString() + ".epd";
+        
     for (const auto& [key, value] : params) {
         if (key == "file") {
             argument_data.tournament_config.epd.file = value;
@@ -245,8 +257,6 @@ void parseEpdOut(const KeyValuePairs& params, ArgumentData& argument_data) {
             OptionsParser::throwMissing("epdout", key, value);
         }
     }
-    if (argument_data.tournament_config.epd.file.empty())
-        throw fastchess_exception("Please specify filename for epd output.");
 }
 
 void parseOpening(const KeyValuePairs& params, ArgumentData& argument_data) {

--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -79,16 +79,6 @@ std::string concat(const std::vector<std::string>& params) {
     return str;
 }
 
-std::string getCurrentTimestampString() {
-    const auto now = std::chrono::system_clock::now();
-    const std::time_t t = std::chrono::system_clock::to_time_t(now);
-
-    std::ostringstream oss;
-    oss << std::put_time(std::localtime(&t), "%Y%m%d_%H%M%S");
-
-    return oss.str();
-}
-
 bool is_number(const std::string& s) {
     static const auto is_digit = [](unsigned char c) { return !std::isdigit(c); };
     return !s.empty() && std::find_if(s.begin(), s.end(), is_digit) == s.end();

--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -202,7 +202,7 @@ void parseEach(const KeyValuePairs& params, ArgumentData& argument_data) {
 }
 
 void parsePgnOut(const KeyValuePairs& params, ArgumentData& argument_data) {
-    argument_data.tournament_config.pgn.file = "fastchess_" + time::datetime("%Y%m%d_%H%M%S") + ".pgn";
+    argument_data.tournament_config.pgn.file = "fastchess_" + time::datetime("%Y%m%d_%H%M%S").value_or("") + ".pgn";
     
     for (const auto& [key, value] : params) {
         if (key == "file") {
@@ -246,7 +246,7 @@ void parsePgnOut(const KeyValuePairs& params, ArgumentData& argument_data) {
 }
 
 void parseEpdOut(const KeyValuePairs& params, ArgumentData& argument_data) {
-    argument_data.tournament_config.epd.file = "fastchess_" + time::datetime("%Y%m%d_%H%M%S") + ".epd";
+    argument_data.tournament_config.epd.file = "fastchess_" + time::datetime("%Y%m%d_%H%M%S").value_or("") + ".epd";
         
     for (const auto& [key, value] : params) {
         if (key == "file") {

--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -733,8 +733,8 @@ OptionsParser::OptionsParser(const cli::Args& args) {
 void OptionsParser::registerOptions() {
     addOption<ParamStyle::KeyValue>("engine", engine::parseEngine);
     addOption<ParamStyle::KeyValue, Dispatch::Deferred>("each", parseEach);
-    addOption<ParamStyle::KeyValue>("pgnout", parsePgnOut);
-    addOption<ParamStyle::KeyValue>("epdout", parseEpdOut);
+    addOption<ParamStyle::KeyValueOptional>("pgnout", parsePgnOut);
+    addOption<ParamStyle::KeyValueOptional>("epdout", parseEpdOut);
     addOption<ParamStyle::KeyValue>("openings", parseOpening);
     addOption<ParamStyle::KeyValue>("sprt", parseSprt);
     addOption<ParamStyle::KeyValue>("draw", parseDraw);

--- a/app/src/cli/cli.hpp
+++ b/app/src/cli/cli.hpp
@@ -46,7 +46,7 @@ struct ArgumentData {
 class OptionsParser {
     using parseFunc = std::function<void(const std::vector<std::string>&, ArgumentData&)>;
 
-    enum class ParamStyle { Free, None, Single, KeyValue };
+    enum class ParamStyle { Free, None, Single, KeyValue, KeyValueOptional };
 
     struct OptionEntry {
         parseFunc func;
@@ -250,6 +250,27 @@ class OptionsParser {
                 if (params.empty()) {
                     throw fastchess_exception("Option \"" + flag + "\" expects key=value parameters.");
                 }
+
+                std::vector<std::pair<std::string, std::string>> kv;
+                kv.reserve(params.size());
+                for (const auto& param : params) {
+                    const auto pos = param.find('=');
+                    if (pos == std::string::npos || pos == 0 || pos + 1 == param.size()) {
+                        throw fastchess_exception("Option \"" + flag + "\" expects key=value pairs, got \"" + param +
+                                                  "\".");
+                    }
+                    kv.emplace_back(param.substr(0, pos), param.substr(pos + 1));
+                }
+
+                fn(kv, data);
+            };
+        } else if constexpr (Style == ParamStyle::KeyValueOptional) {
+            static_assert(std::is_invocable_r_v<void, Handler, const std::vector<std::pair<std::string, std::string>>&,
+                                                ArgumentData&>,
+                          "Handler must accept (key/value list, ArgumentData&)");
+            std::function<void(const std::vector<std::pair<std::string, std::string>>&, ArgumentData&)> fn =
+                std::forward<Handler>(handler);
+            return [flag, fn](const std::vector<std::string>& params, ArgumentData& data) {
 
                 std::vector<std::pair<std::string, std::string>> kv;
                 kv.reserve(params.size());

--- a/app/tests/cli_test.cpp
+++ b/app/tests/cli_test.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <iterator>
 #include <vector>
+#include <regex>
 
 #include <doctest/doctest.hpp>
 
@@ -412,6 +413,37 @@ TEST_SUITE("Option Parsing Tests") {
         };
         CHECK(hasHash(engines[0]));
         CHECK(hasHash(engines[1]));
+    }
+
+    TEST_CASE("Default filename for pgnout and epdout") {
+        const auto args = cli::Args{"fastchess.exe",
+                                    "-engine",
+                                    "dir=./",
+                                    "cmd=app/tests/mock/engine/dummy_engine",
+                                    "depth=5",
+                                    "st=5",
+                                    "name=Alexandria-EA649FED",
+                                    "-engine",
+                                    "dir=./",
+                                    "cmd=app/tests/mock/engine/dummy_engine",
+                                    "tc=40/1:9.65+0.1",
+                                    "name=Alexandria-27E42728",
+                                    "-openings",
+                                    "file=./app/tests/data/test.epd",
+                                    "-rounds",
+                                    "50",
+                                    "-games",
+                                    "2",
+                                    "-pgnout",
+                                    "-epdout"};
+
+        cli::OptionsParser options = cli::OptionsParser(args);
+
+        const std::regex epd_pattern(R"(fastchess_\d{8}_\d{6}\.epd)");
+        const std::regex pgn_pattern(R"(fastchess_\d{8}_\d{6}\.pgn)");
+
+        CHECK(std::regex_match(options.getTournamentConfig().pgn.file, pgn_pattern));
+        CHECK(std::regex_match(options.getTournamentConfig().epd.file, epd_pattern));
     }
 
     TEST_CASE("Scalar options update tournament config") {


### PR DESCRIPTION
format looks like: `fastchess_20260624_080530.pgn/.epd`. i considered doing engine1_vs_engine2_timestamp but that doesnt really work out in a tournament of more than 2 engines and might exceed max character limits.