### PR TITLE
feat: add an `iid` order type for opening books

### DIFF
--- a/app/src/cli/cli.cpp
+++ b/app/src/cli/cli.cpp
@@ -193,7 +193,7 @@ void parseEach(const KeyValuePairs& params, ArgumentData& argument_data) {
 
 void parsePgnOut(const KeyValuePairs& params, ArgumentData& argument_data) {
     argument_data.tournament_config.pgn.file = "fastchess_" + time::datetime("%Y%m%d_%H%M%S").value_or("") + ".pgn";
-    
+
     for (const auto& [key, value] : params) {
         if (key == "file") {
             argument_data.tournament_config.pgn.file = value;
@@ -237,7 +237,7 @@ void parsePgnOut(const KeyValuePairs& params, ArgumentData& argument_data) {
 
 void parseEpdOut(const KeyValuePairs& params, ArgumentData& argument_data) {
     argument_data.tournament_config.epd.file = "fastchess_" + time::datetime("%Y%m%d_%H%M%S").value_or("") + ".epd";
-        
+
     for (const auto& [key, value] : params) {
         if (key == "file") {
             argument_data.tournament_config.epd.file = value;
@@ -277,6 +277,8 @@ void parseOpening(const KeyValuePairs& params, ArgumentData& argument_data) {
                 argument_data.tournament_config.opening.order = OrderType::SEQUENTIAL;
             } else if (value == "random") {
                 argument_data.tournament_config.opening.order = OrderType::RANDOM;
+            } else if (value == "iid") {
+                argument_data.tournament_config.opening.order = OrderType::RANDOM_IID;
             } else {
                 OptionsParser::throwMissing("openings order", key, value);
             }

--- a/app/src/game/book/opening_book.cpp
+++ b/app/src/game/book/opening_book.cpp
@@ -44,7 +44,7 @@ void OpeningBook::setup(const std::string& file, FormatType type, VariantType vt
 
     if (order_ == OrderType::RANDOM_IID) {
         Logger::print("Indexing opening suite...");
-        std::visit([](auto& arg) { Openings::resample(arg.get(), rounds_ * games_); }, openings_);
+        std::visit([num_matches = rounds_ * games_](auto& arg) { Openings::resample(arg.get(), num_matches); }, openings_);
     }
 
     if (offset_ > 0) {

--- a/app/src/game/book/opening_book.cpp
+++ b/app/src/game/book/opening_book.cpp
@@ -44,7 +44,7 @@ void OpeningBook::setup(const std::string& file, FormatType type, VariantType vt
 
     if (order_ == OrderType::RANDOM_IID) {
         Logger::print("Indexing opening suite...");
-        std::visit([num_matches = rounds_ * games_](auto& arg) { Openings::resample(arg.get(), num_matches); }, openings_);
+        std::visit([num_matches = rounds_](auto& arg) { Openings::resample(arg.get(), num_rounds); }, openings_);
     }
 
     if (offset_ > 0) {

--- a/app/src/game/book/opening_book.cpp
+++ b/app/src/game/book/opening_book.cpp
@@ -44,7 +44,7 @@ void OpeningBook::setup(const std::string& file, FormatType type, VariantType vt
 
     if (order_ == OrderType::RANDOM_IID) {
         Logger::print("Indexing opening suite...");
-        std::visit([num_matches = rounds_](auto& arg) { Openings::resample(arg.get(), num_rounds); }, openings_);
+        std::visit([num_rounds = rounds_](auto& arg) { Openings::resample(arg.get(), num_rounds); }, openings_);
     }
 
     if (offset_ > 0) {

--- a/app/src/game/book/opening_book.cpp
+++ b/app/src/game/book/opening_book.cpp
@@ -42,6 +42,11 @@ void OpeningBook::setup(const std::string& file, FormatType type, VariantType vt
         std::visit([](auto& arg) { Openings::shuffle(arg.get()); }, openings_);
     }
 
+    if (order_ == OrderType::RANDOM_IID) {
+        Logger::print("Indexing opening suite...");
+        std::visit([](auto& arg) { Openings::resample(arg.get(), rounds_ * games_); }, openings_);
+    }
+
     if (offset_ > 0) {
         LOG_INFO("Offsetting the opening book by {} openings...", offset_);
         std::visit([offset = offset_](auto& arg) { Openings::rotate(arg.get(), offset); }, openings_);

--- a/app/src/game/book/opening_book.hpp
+++ b/app/src/game/book/opening_book.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <variant>
 #include <vector>
+#include <random>
 
 #include <core/config/config.hpp>
 #include <core/helper.hpp>
@@ -23,6 +24,21 @@ struct Openings {
             auto rand     = random::mersenne_rand();
             std::size_t j = i + (rand % (vec.size() - i));
             std::swap(vec[i], vec[j]);
+        }
+    }
+
+    // Resampling with replacement
+    template <typename T>
+    static void resample(T& vec, std::size_t num_games) {
+        if (vec.empty())
+            return;
+
+        T original = vec;
+        vec.resize(num_games);
+
+        std::uniform_int_distribution<uint64_t> dist(0, original.size() - 1);
+        for (std::size_t i = 0; i < num_games; ++i) {
+            vec[i] = original[dist(random::mersenne_rand)];
         }
     }
 

--- a/app/src/game/book/opening_book.hpp
+++ b/app/src/game/book/opening_book.hpp
@@ -29,15 +29,15 @@ struct Openings {
 
     // Resampling with replacement
     template <typename T>
-    static void resample(T& vec, std::size_t num_games) {
+    static void resample(T& vec, std::size_t num_matches) {
         if (vec.empty())
             return;
 
         T original = vec;
-        vec.resize(num_games);
+        vec.resize(num_matches);
 
         std::uniform_int_distribution<uint64_t> dist(0, original.size() - 1);
-        for (std::size_t i = 0; i < num_games; ++i) {
+        for (std::size_t i = 0; i < num_matches; ++i) {
             vec[i] = original[dist(random::mersenne_rand)];
         }
     }

--- a/app/src/game/book/opening_book.hpp
+++ b/app/src/game/book/opening_book.hpp
@@ -29,15 +29,15 @@ struct Openings {
 
     // Resampling with replacement
     template <typename T>
-    static void resample(T& vec, std::size_t num_matches) {
+    static void resample(T& vec, std::size_t num_rounds) {
         if (vec.empty())
             return;
 
         T original = vec;
-        vec.resize(num_matches);
+        vec.resize(num_rounds);
 
         std::uniform_int_distribution<uint64_t> dist(0, original.size() - 1);
-        for (std::size_t i = 0; i < num_matches; ++i) {
+        for (std::size_t i = 0; i < num_rounds; ++i) {
             vec[i] = original[dist(random::mersenne_rand)];
         }
     }

--- a/app/src/types/enums.hpp
+++ b/app/src/types/enums.hpp
@@ -3,7 +3,7 @@
 namespace fastchess {
 
 enum class NotationType { SAN, LAN, UCI };
-enum class OrderType { RANDOM, SEQUENTIAL };
+enum class OrderType { RANDOM, RANDOM_IID, SEQUENTIAL };
 enum class FormatType { EPD, PGN, NONE };
 enum class VariantType { STANDARD, FRC };
 enum class TournamentType { ROUNDROBIN, GAUNTLET };

--- a/man.md
+++ b/man.md
@@ -133,11 +133,11 @@ The default values are the first value in parentheses.
 
 ## Opening Book Management
 
-- `-openings file=NAME format=(epd|pgn) [order=(sequential|random)] [plies=(Max plies|N)] [start=(1|N)]`  
+- `-openings file=NAME format=(epd|pgn) [order=(sequential|random|iid)] [plies=(Max plies|N)] [start=(1|N)]`  
     Specifies an opening book file and its format for game starting positions.
 
     - `format` - file format, either epd or pgn.
-    - `order` - order of openings (`random` or `sequential`). Default is `sequential`.
+    - `order` - order of openings (`random`, `iid` or `sequential`). Default is `sequential`.
     - `plies` - number of plies for pgn. Defaults to max available plies.
     - `start` - starting index of the opening book. Default is 1.
 


### PR DESCRIPTION
This order type is used for statistical tests that requires the opening selection to be independent and identically distributed (iid).

closes https://github.com/Disservin/fastchess/issues/1034