### PR TITLE
fix: deadlock engine nodes crash

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -70,6 +70,13 @@ jobs:
           ${{ runner.os == 'Windows' && format('make -j2 tests CXX={0}', matrix.config.cxx) || 'make -j2 tests' }}
           ./fastchess-tests*
 
+      - name: Running pipe interrupt fallback regression
+        if: runner.os == 'Linux'
+        env:
+          FASTCHESS_FORCE_PIPE_INTERRUPT: 1
+        run: |
+          ./fastchess-tests*
+
   # AddressSanitizer tests (Unix only)
   asan-tests:
     name: AddressSanitizer Tests - ${{matrix.config.name}}

--- a/app/src/engine/process/interrupt.hpp
+++ b/app/src/engine/process/interrupt.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdlib>
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -48,11 +49,13 @@ class InterruptSignaler {
 
     void setup() {
 #if CAN_USE_EVENTFD_FLAGS
-        fd_read_ = eventfd(0, EFD_CLOEXEC);
-        if (fd_read_ != -1) {
-            // eventfd uses same FD for both
-            fd_write_ = fd_read_;
-            return;
+        if (!force_pipe_fallback()) {
+            fd_read_ = eventfd(0, EFD_CLOEXEC);
+            if (fd_read_ != -1) {
+                // eventfd uses same FD for both
+                fd_write_ = fd_read_;
+                return;
+            }
         }
 #endif
         int pipefds[2];
@@ -87,6 +90,11 @@ class InterruptSignaler {
     }
 
    private:
+    static bool force_pipe_fallback() {
+        const char* value = std::getenv("FASTCHESS_FORCE_PIPE_INTERRUPT");
+        return value != nullptr && *value != '\0' && value[0] != '0';
+    }
+
     int fd_read_  = -1;
     int fd_write_ = -1;
 };

--- a/app/src/engine/process/process_posix.hpp
+++ b/app/src/engine/process/process_posix.hpp
@@ -194,11 +194,15 @@ class Process : public IProcess {
         // which are killed when the program exits, as a last resort
         process_list.push(ProcessInformation{process_pid_, interrupt_.get_write_fd()});
 
+        // Close the parent's duplicates of the child-owned pipe ends so EOF/HUP
+        // is observable when the child exits. macOS uses a pipe-based interrupt
+        // fallback, so this cannot depend on eventfd availability.
+        in_pipe_.close_write_end();
+        err_pipe_.close_write_end();
+        out_pipe_.close_read_end();
+
         if (interrupt_.has_eventfd()) {
             LOG_TRACE("Using eventfd for process interrupt signaling");
-            in_pipe_.close_write_end();
-            err_pipe_.close_write_end();
-            out_pipe_.close_read_end();
         }
 
         return Result::OK();

--- a/app/src/engine/process/process_win.hpp
+++ b/app/src/engine/process/process_win.hpp
@@ -189,16 +189,34 @@ class Process : public IProcess {
             if (!ReadFile(hChildStdoutRead, buffer.data(), buffer.size(), &bytesRead, &overlapped)) {
                 if (GetLastError() != ERROR_IO_PENDING) {
                     CloseHandle(overlapped.hEvent);
+
+                    if (!alive()) {
+                        return Result::Error("process terminated");
+                    }
+
                     LOG_FATAL_THREAD("Failed to read from pipe");
                     return Result::Error("failed to read from pipe");
                 }
 
-                DWORD waitResult = WaitForSingleObject(overlapped.hEvent, timeout);
+                HANDLE wait_handles[] = {overlapped.hEvent, pi_.hProcess};
+                DWORD waitResult = WaitForMultipleObjects(2, wait_handles, FALSE, timeout);
                 if (waitResult == WAIT_TIMEOUT) {
                     CancelIo(hChildStdoutRead);
                     CloseHandle(overlapped.hEvent);
                     return Result{Status::TIMEOUT, "timeout"};
                 }
+
+                if (waitResult == WAIT_OBJECT_0 + 1) {
+                    CloseHandle(overlapped.hEvent);
+
+                    if (!alive()) {
+                        return Result::Error("process terminated");
+                    }
+
+                    LOG_FATAL_THREAD("Process handle signaled but process is still alive");
+                    return Result::Error("wait failed");
+                }
+
                 if (waitResult != WAIT_OBJECT_0) {
                     CloseHandle(overlapped.hEvent);
                     LOG_FATAL_THREAD("Wait failed");
@@ -207,6 +225,11 @@ class Process : public IProcess {
 
                 if (!GetOverlappedResult(hChildStdoutRead, &overlapped, &bytesRead, FALSE)) {
                     CloseHandle(overlapped.hEvent);
+
+                    if (!alive()) {
+                        return Result::Error("process terminated");
+                    }
+
                     LOG_FATAL_THREAD("Failed to get overlapped result");
                     return Result::Error("failed to get overlapped result");
                 }
@@ -215,6 +238,10 @@ class Process : public IProcess {
             CloseHandle(overlapped.hEvent);
 
             if (bytesRead == 0) {
+                if (!alive()) {
+                    return Result::Error("process terminated");
+                }
+
                 continue;
             }
 

--- a/app/tests/mock/engine/dummy_engine.cpp
+++ b/app/tests/mock/engine/dummy_engine.cpp
@@ -11,9 +11,14 @@ using namespace std;
 int main(int argc, char const *argv[]) {
     std::vector<std::string> moves = {"f2f3", "e7e5", "g2g4", "d8h4"};
     int moveIndex                  = 0;
+    bool crash_on_go_nodes         = false;
 
     if (argc > 1) {
         for (int i = 1; i < argc; i++) {
+            if (std::string_view(argv[i]) == "--crash-on-go-nodes") {
+                crash_on_go_nodes = true;
+            }
+
             std::cout << "argv[" << i << "]: " << argv[i] << std::endl;
         }
     }
@@ -81,6 +86,10 @@ int main(int argc, char const *argv[]) {
                 }
             }
         } else if (contains(cmd, "go")) {
+            if (crash_on_go_nodes && contains(cmd, " nodes ")) {
+                return 1;
+            }
+
             std::cout << "bestmove " << moves[moveIndex] << std::endl;
         } else if (contains(cmd, "setoption")) {
             // Simulate setting an option

--- a/app/tests/uci_engine_test.cpp
+++ b/app/tests/uci_engine_test.cpp
@@ -275,4 +275,19 @@ TEST_SUITE("Uci Engine Communication Tests") {
         CHECK(uci_engine->getStdoutLines()[2]->line == "option set: setoption name MultiPV value 3");
         CHECK(uci_engine->getStdoutLines()[3]->line == "option set: setoption name UCI_Chess960 value true");
     }
+
+    TEST_CASE("Detect crashed engine while waiting for bestmove with fixed nodes") {
+        engine::process::Process process;
+        std::vector<engine::process::Line> output;
+
+        process.setRealtimeLogging(false);
+
+        CHECK(process.init(".", std::string(path), "--crash-on-go-nodes", "dummy").code ==
+              engine::process::Status::OK);
+        CHECK(process.writeInput("go nodes 1\n").code == engine::process::Status::OK);
+
+        const auto res = process.readOutput(output, "bestmove", std::chrono::milliseconds(0));
+
+        CHECK(res.code == engine::process::Status::ERR);
+    }
 }


### PR DESCRIPTION
The problem occurs on windows because with fixed nodes we have an infinite wait on the engine output, but because the engine crashes and doesn't send any new output we deadlock.
Wait on the process itself too, to detect a crash.

fixes https://github.com/Disservin/fastchess/issues/1029